### PR TITLE
fix for updating recovery email

### DIFF
--- a/app/models/concerns/confirmable/recovery_email.rb
+++ b/app/models/concerns/confirmable/recovery_email.rb
@@ -197,6 +197,7 @@ module Confirmable::RecoveryEmail
     self.unconfirmed_recovery_email = recovery_email
     self.recovery_email = recovery_email_was
     self.recovery_confirmation_token = nil
+    self.recovery_confirmed_at = nil # unset to allow change
     generate_recovery_confirmation_token
   end
 


### PR DESCRIPTION
on change unset recovery_confirmation_at so the changed address can be confirmed and activated

resolves https://github.com/Samedis-care/samedis-care-issues/issues/1353#issuecomment-2072751771