### PR TITLE
Add support for background CSS prop override in frontend

### DIFF
--- a/app/controllers/api/v1/app_admin_controller.rb
+++ b/app/controllers/api/v1/app_admin_controller.rb
@@ -40,7 +40,7 @@ class Api::V1::AppAdminController < Api::V1::JsonApiController
           theme: [
             { primary: [:main, :light, :dark] },
             { secondary: [:main, :light, :dark] },
-            { background: [:default] },
+            { background: [:default, :advanced] },
             { components_care: [
                 { ui_kit: [ { action_button: [:background_color]} ] }
               ]

--- a/app/models/actors/app.rb
+++ b/app/models/actors/app.rb
@@ -153,6 +153,7 @@ module Actors
           include Mongoid::Document
           embedded_in :theme
           field :default, type: String, default: "rgb(185, 215, 240)"
+          field :advanced, type: String
         end
         class ComponentsCare
           include Mongoid::Document

--- a/app/serializers/app_admin_serializer.rb
+++ b/app/serializers/app_admin_serializer.rb
@@ -67,7 +67,7 @@ class AppAdminSerializer
       theme: {
         primary: app&.config&.theme&.primary.attributes.symbolize_keys.slice(:main, :light, :dark),
         secondary: app&.config&.theme&.secondary.attributes.symbolize_keys.slice(:main, :light, :dark),
-        background: app&.config&.theme&.background.attributes.symbolize_keys.slice(:default),
+        background: app&.config&.theme&.background.attributes.symbolize_keys.slice(:default, :advanced),
         components_care: {
           ui_kit: {
             action_button: app&.config&.theme&.components_care&.ui_kit&.action_button.attributes.symbolize_keys.slice(:background_color),
@@ -163,8 +163,9 @@ class AppAdminSerializer
                 string :light, description: 'lighter variant of the secondary color'
                 string :dark, description: 'darker variant of the secondary color'
               end
-              object :background, description: 'secondary colors' do
+              object :background, description: 'background' do
                 string :default, description: 'background color'
+                string :advanced, description: 'background CSS property', nullable: true
               end
               object :components_care, description: 'components care specific settings' do
                 object :ui_kit, description: 'theme settings for ui_kit' do

--- a/app/serializers/app_info_serializer.rb
+++ b/app/serializers/app_info_serializer.rb
@@ -39,7 +39,7 @@ class AppInfoSerializer
       theme: {
         primary: app&.config&.theme&.primary.attributes.symbolize_keys.slice(:main, :light, :dark),
         secondary: app&.config&.theme&.secondary.attributes.symbolize_keys.slice(:main, :light, :dark),
-        background: app&.config&.theme&.background.attributes.symbolize_keys.slice(:default),
+        background: app&.config&.theme&.background.attributes.symbolize_keys.slice(:default, :advanced),
         components_care: {
           ui_kit: {
             action_button: app&.config&.theme&.components_care&.ui_kit&.action_button.attributes.symbolize_keys.slice(:background_color),
@@ -111,8 +111,9 @@ class AppInfoSerializer
                 string :light, description: 'lighter variant of the secondary color'
                 string :dark, description: 'darker variant of the secondary color'
               end
-              object :background, description: 'secondary colors' do
+              object :background, description: 'background' do
                 string :default, description: 'background color'
+                string :advanced, description: 'background CSS property', nullable: true
               end
               object :components_care, description: 'components care specific settings' do
                 object :ui_kit, description: 'theme settings for ui_kit' do


### PR DESCRIPTION
could not run auto swagger because leave_tenant_controller has no serializers defined

resolves https://github.com/Samedis-care/samedis-care-issues/issues/1701