### PR TITLE
rubocop config update

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,13 @@
+require:
+  - rubocop-rails
+  - rubocop-rspec
+  - rubocop-rspec_rails
+  - rubocop-factory_bot
+
+AllCops:
+  ParserEngine: parser_prism
+  TargetRubyVersion: 3.3
+
 Style/Lambda:
   Enabled: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,21 +16,21 @@ COPY Gemfile Gemfile.lock ./
 RUN gem install bundler:$(cat Gemfile.lock | grep -A 1 "BUNDLED WITH" | grep -Po '[0-9]+\.[0-9]+\.[0-9]+')
 RUN bundle install
 
-ENV HOME /root
+ENV HOME=/root
 
 # Set Rails ENV variables
-ENV RAILS_LOG_TO_STDOUT true
+ENV RAILS_LOG_TO_STDOUT=true
 # Use jemalloc
 RUN ln -s /usr/lib/*-linux-gnu/libjemalloc.so.2 /usr/lib/libjemalloc.so.2
 ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
 
-ENV MALLOC_CONF narenas:2,background_thread:true,abort_conf:true
+ENV MALLOC_CONF=narenas:2,background_thread:true,abort_conf:true
 # Glibc malloc
 #ENV MALLOC_ARENA_MAX 2
 
 # Add the Rails app
 ADD . /home/app/webapp
-ENV PATH "$PATH:/home/app/webapp/bin"
+ENV PATH="$PATH:/home/app/webapp/bin"
 ENV RUBY_YJIT_ENABLE=1
 
 # Download MaxMind GeoIP Database

--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,12 @@ group :development, :test, :live, :local_dev, :staging do
   gem 'clipboard'
   gem 'colorize'
   gem 'mongo_logs_on_roids'
+  gem 'prism'
+  gem 'rubocop', require: false
+  gem 'rubocop-factory_bot', require: false
+  gem 'rubocop-rails', require: false
+  gem 'rubocop-rspec', require: false
+  gem 'rubocop-rspec_rails', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     aes_key_wrap (1.1.0)
+    ast (2.4.2)
     awesome_print (1.9.2)
     aws-eventstream (1.3.0)
     aws-partitions (1.970.0)
@@ -183,6 +184,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
+    json (2.7.2)
     json-jwt (1.16.6)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -203,6 +205,7 @@ GEM
     kaminari-mongoid (1.0.2)
       kaminari-core (~> 1.0)
       mongoid
+    language_server-protocol (3.17.0.3)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -296,6 +299,10 @@ GEM
     orm_adapter (0.5.0)
     ostruct (0.6.0)
     parallel (1.26.3)
+    parser (3.3.4.2)
+      ast (~> 2.4.1)
+      racc
+    prism (1.0.0)
     psych (3.3.4)
     public_suffix (6.0.1)
     puma (6.4.2)
@@ -341,12 +348,14 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
+    rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rdoc (6.3.4.1)
     recaptcha (5.17.0)
+    regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
     responders (3.1.1)
@@ -393,6 +402,30 @@ GEM
     rswag-ui (2.14.0)
       actionpack (>= 5.2, < 8.0)
       railties (>= 5.2, < 8.0)
+    rubocop (1.66.0)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rubocop-ast (>= 1.32.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.32.2)
+      parser (>= 3.3.1.0)
+    rubocop-factory_bot (2.26.1)
+      rubocop (~> 1.61)
+    rubocop-rails (2.26.0)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.52.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rspec (3.0.4)
+      rubocop (~> 1.61)
+    rubocop-rspec_rails (2.30.0)
+      rubocop (~> 1.61)
+      rubocop-rspec (~> 3, >= 3.0.1)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.2)
       ffi (~> 1.12)
@@ -425,6 +458,7 @@ GEM
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2024.1)
       tzinfo (>= 1.0.0)
+    unicode-display_width (2.5.0)
     uri (0.13.1)
     version_gem (1.1.4)
     warden (1.2.9)
@@ -479,6 +513,7 @@ DEPENDENCIES
   omniauth-microsoft_graph
   omniauth-rails_csrf_protection
   parallel
+  prism
   psych (< 4)
   puma
   rails (~> 7.1)
@@ -487,6 +522,11 @@ DEPENDENCIES
   rspec
   rspec-rails
   rswag
+  rubocop
+  rubocop-factory_bot
+  rubocop-rails
+  rubocop-rspec
+  rubocop-rspec_rails
   ruby-progressbar
   ruby-vips
   sawyer


### PR DESCRIPTION
- use ruby 3.3 syntax for rubocop
- use prism parser for rubocop (much faster)
- add and require relevant gems

- Dockerfile syntax warnings fixed