### PR TITLE
remove semantic logger from standard envs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,8 +81,6 @@ gem 'awesome_print'
 gem 'parallel'
 gem 'ruby-progressbar'
 
-gem 'rails_semantic_logger'
-
 group :development, :test, :live, :local_dev, :staging do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'brakeman'
@@ -101,3 +99,8 @@ end
 group :development do
   gem 'listen'
 end
+
+group :local_dev, :live, :dev do
+  gem 'rails_semantic_logger', require: false
+end
+

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -76,4 +76,20 @@ Rails.application.configure do
   require "awesome_print"
   AwesomePrint.irb!
 
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    config.log_level = :info
+    config.colorize_logging = false
+
+    if defined? SemanticLogger
+      $stdout.sync = true
+      config.rails_semantic_logger.add_file_appender = false
+      config.semantic_logger.backtrace_level = :error
+      config.semantic_logger.add_appender(io: $stdout, formatter: config.rails_semantic_logger.format)
+    else
+      logger           = ActiveSupport::Logger.new($stdout)
+      logger.formatter = config.log_formatter
+      config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    end
+  end
+
 end

--- a/config/environments/local_dev.rb
+++ b/config/environments/local_dev.rb
@@ -61,6 +61,7 @@ Rails.application.configure do
   require "awesome_print"
   AwesomePrint.irb!
 
+  require 'rails_semantic_logger'
   if ENV['RAILS_LOG_TO_STDOUT'].present?
     # config.log_level = :info
     # logger           = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
semantic logger doesn't like docker STDOUT and logs to file anyhow when present