### PR TITLE
role security on custom profiles

### DIFF
--- a/app/controllers/api/v1/access_control/tenant/roles_controller.rb
+++ b/app/controllers/api/v1/access_control/tenant/roles_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::AccessControl::Tenant::RolesController < Api::V1::JsonApiControll
 
   MODEL_BASE = Role
   MODEL = -> {
-    current_app_actor.roles.available
+    current_app_actor.roles.where(:_id.in => tenant_role_ids).available
   }
   MODEL_OVERVIEW = MODEL
   SERIALIZER = RolePickerSerializer
@@ -16,6 +16,15 @@ class Api::V1::AccessControl::Tenant::RolesController < Api::V1::JsonApiControll
   undef_method :destroy
 
   private
+
+  # ensures the roles returned are reduced
+  # to only those that the current_tenant has available
+  # within the organization structure (as defined by app orga)
+  # this is critical to avoid exposing highly privileged
+  # administative roles
+  def tenant_role_ids
+    @tenant_role_ids ||= current_tenant_actor.available_role_ids
+  end
 
   def cando
     CANDO.merge({

--- a/app/models/actors/group.rb
+++ b/app/models/actors/group.rb
@@ -2,8 +2,17 @@ module Actors
 
   class Group < Actor
 
+    validate :safe_role_ids
+
+    def safe_role_ids
+      return unless parent_ids.include?(tenant&.profiles_ou&.id) # only needs to check profiles (below that OU)
+      return unless (role_ids - tenant.available_role_ids).any? # prevent unsafe/non organization roles
+
+      errors.add(:base, 'This group cannot have role ids that are not included within the tenant organization')
+    end
+
     def self.global_admins
-      @@global_admins ||= where(short_name: :global_admins).first_or_create(system: true, write_protected: true)
+      @global_admins ||= where(short_name: :global_admins).first_or_create(system: true, write_protected: true)
     end
 
   end

--- a/app/models/actors/tenant.rb
+++ b/app/models/actors/tenant.rb
@@ -95,6 +95,12 @@ module Actors
       profiles_ou.children.reorder(nil).where(_type: Actors::Group, parent_id: profiles_ou.id)
     end
 
+    def available_role_ids
+      @available_role_ids ||= organization
+                              .descendants
+                              .groups.pluck(:role_ids).flatten.compact.uniq
+    end
+
     def self.enterprises(tenant_ids)
       begin
         _enterprise_ids = Actors::Mapping.unscoped.available.where(:map_actor_id.in => ensure_bson(tenant_ids)).pluck(:parent_id)


### PR DESCRIPTION
implemented logic that

- only returns roles within a tenant organization (to prevent exposing admin roles)
- for groups below the profiles OU validate given role_ids to prevent adding such roles