### PR TITLE
Fix Microsoft multi-tenant issuer validation in SocialTokenVerifier

### DIFF
--- a/app/services/social_token_verifier.rb
+++ b/app/services/social_token_verifier.rb
@@ -27,6 +27,9 @@ class SocialTokenVerifier
     'microsoft' => {
       jwks_uri: 'https://login.microsoftonline.com/common/discovery/v2.0/keys',
       issuers: :microsoft_issuers,
+      # Multi-tenant apps receive tenant-specific issuers (e.g. /{tenant-uuid}/v2.0)
+      # even when the app is configured with tenantId "common"
+      issuer_pattern: %r{\Ahttps://login\.microsoftonline\.com/[0-9a-f\-]{36}/v2\.0\z},
       audiences: -> { microsoft_client_ids }
     }
   }.freeze
@@ -81,10 +84,14 @@ class SocialTokenVerifier
   end
 
   def validate_issuer!(claims)
+    iss = claims['iss']
     issuers = resolve_issuers
-    return if issuers.include?(claims['iss'])
+    return if issuers.include?(iss)
 
-    raise VerificationError, "Invalid issuer: #{claims['iss']}"
+    issuer_pattern = @config[:issuer_pattern]
+    return if issuer_pattern&.match?(iss)
+
+    raise VerificationError, "Invalid issuer: #{iss}"
   end
 
   def validate_audience!(claims)

--- a/spec/services/social_token_verifier_spec.rb
+++ b/spec/services/social_token_verifier_spec.rb
@@ -189,5 +189,20 @@ RSpec.describe SocialTokenVerifier do
       verifier = described_class.new(provider:, id_token: token)
       expect { verifier.verify! }.not_to raise_error
     end
+
+    it 'accepts tenant-uuid issuer for multi-tenant apps (common endpoint returns tenant-specific iss)' do
+      # When the iOS app uses tenantId "common", Microsoft still returns tokens
+      # with the real tenant UUID in the issuer, e.g. /d84b06ae-.../v2.0
+      tenant_issuer = 'https://login.microsoftonline.com/d84b06ae-25e4-49ea-9898-6d015cb59f68/v2.0'
+      token = build_token(valid_claims.merge('iss' => tenant_issuer))
+      verifier = described_class.new(provider:, id_token: token)
+      expect { verifier.verify! }.not_to raise_error
+    end
+
+    it 'rejects an issuer that looks like a tenant UUID but has an invalid format' do
+      token = build_token(valid_claims.merge('iss' => 'https://login.microsoftonline.com/not-a-uuid/v2.0'))
+      verifier = described_class.new(provider:, id_token: token)
+      expect { verifier.verify! }.to raise_error(described_class::VerificationError, /Invalid issuer/)
+    end
   end
 end


### PR DESCRIPTION
When an iOS app uses tenantId "common", Microsoft returns tokens with a tenant-specific issuer (e.g. /d84b06ae-.../v2.0) instead of /common/v2.0. Accept any valid tenant UUID issuer via issuer_pattern regex.