### PR TITLE
APAC migration: leak guard + verify correct for a live target

### DIFF
--- a/docs/apac_migration.md
+++ b/docs/apac_migration.md
@@ -92,7 +92,7 @@ RAILS_ENV=live TARGET_MONGODB_URI=... bundle exec rake apac:copy DRY_RUN=true   
 RAILS_ENV=live TARGET_MONGODB_URI=... bundle exec rake apac:copy                # Mongo: full copy
 RAILS_ENV=live TARGET_S3_BUCKET=... ... bundle exec rake apac:copy_s3           # S3: images/avatars
 RAILS_ENV=live bundle exec rake apac:report_dangling                            # cross-region refs → clarify
-RAILS_ENV=live TARGET_MONGODB_URI=... bundle exec rake apac:verify              # counts + leak guard
+RAILS_ENV=live TARGET_MONGODB_URI=... bundle exec rake apac:verify              # completeness + leak guard
 ```
 
 > `apac:copy_s3` is idempotent (skips keys already on the target) and only ever
@@ -151,8 +151,12 @@ on copy and regenerate on first APAC login.
 `ApacMigration::CollectionRegistry.assert_complete!` runs before every copy and
 **raises** if any `tenant_id`-bearing model is neither classified as copied nor
 excluded — so a future tenant-scoped collection cannot silently leak or be
-forgotten. After each real copy, `ApacMigration::LeakGuard` asserts on the target:
-no Mapping/Invite with a non-APAC `tenant_id`, no user with leftover EU caches.
+forgotten. After each real copy, `ApacMigration::LeakGuard` asserts on the target
+that nothing references an **EU source tenant** (the set of source tenants not in
+the APAC set): no Mapping/Invite/Tenant tied to an EU tenant, and no user caching
+an EU tenant in `tenants_cached` or as a key of `tenant_access_group_ids` /
+`tenant_candos_cached`. Records created natively on the live APAC cluster (absent
+from the source) are correctly ignored — see `apac:verify` below.
 
 ---
 
@@ -184,6 +188,8 @@ Configure per the existing schema:
 - `bundle exec rspec spec/models/actors/tenant_spec.rb spec/lib/apac_migration`
 - `apac:mark_region ... DRY_RUN=true` shows the right selection, writes nothing.
 - `apac:copy DRY_RUN=true` selection contains **zero** EU-only tenants/identities.
-- After a test copy against a throwaway cluster: `apac:verify` counts match and the
-  leak guard passes; copied users have **empty** EU cache fields.
+- After a test copy against a throwaway cluster: `apac:verify` reports every set
+  as `OK` (all source docs present; extra native target docs shown as `(+N
+  native on target)`) and the leak guard passes; copied users have **empty** EU
+  cache fields.
 - In SCB: after `mark_region`, `region` is visible in `view_samedis_care_actors`.

--- a/lib/apac_migration/leak_guard.rb
+++ b/lib/apac_migration/leak_guard.rb
@@ -8,41 +8,36 @@ module ApacMigration
     end
 
     def assert!(target_client)
-      apac = @resolver.apac_tenant_ids
-      # Invite#tenant_id is `type: Object` and stored as a mix of String and
-      # BSON::ObjectId, so match both representations (Mapping#tenant_id is a
-      # clean ObjectId and only needs `apac`).
-      apac_mixed = apac + apac.map(&:to_s)
+      # Blacklist of EU tenants that exist in the SOURCE. Anything on the target
+      # tied to one of these is a genuine leak; records created natively on the
+      # (live) APAC cluster are not in this set and are correctly ignored.
+      eu = @resolver.eu_tenant_ids
+      # Invite#tenant_id is `type: Object`, stored as a mix of String and
+      # BSON::ObjectId — match both. Mapping#tenant_id is a clean ObjectId.
+      eu_mixed = eu + eu.map(&:to_s)
       errors = []
 
-      # 1. Every Mapping on the target must point at an APAC tenant.
+      # 1. No Mapping on the target may point at an EU source tenant.
       bad_map = target_client['actors'].find(
         '_type' => 'Actors::Mapping',
-        'tenant_id' => { '$nin' => apac }
+        'tenant_id' => { '$in' => eu }
       ).first
-      errors << "actors: Mapping #{bad_map['_id']} has non-APAC tenant_id #{bad_map['tenant_id']}" if bad_map
+      errors << "actors: Mapping #{bad_map['_id']} points at EU tenant #{bad_map['tenant_id']}" if bad_map
 
-      # 1b. Every Tenant actor on the target must be in the APAC set (guards the
-      #     structural-ancestor copy from ever pulling in a sibling tenant).
+      # 2. No EU source Tenant may exist on the target.
       bad_tenant = target_client['actors'].find(
         '_type' => 'Actors::Tenant',
-        '_id' => { '$nin' => apac }
+        '_id' => { '$in' => eu }
       ).first
-      errors << "actors: Tenant #{bad_tenant['_id']} is not in the APAC set" if bad_tenant
+      errors << "actors: EU Tenant #{bad_tenant['_id']} present on target" if bad_tenant
 
-      # 2. Every Invite on the target must belong to an APAC tenant.
-      bad_inv = target_client['invites'].find('tenant_id' => { '$nin' => apac_mixed }).first
-      errors << "invites: #{bad_inv['_id']} has non-APAC tenant_id #{bad_inv['tenant_id']}" if bad_inv
+      # 3. No Invite on the target may belong to an EU source tenant.
+      bad_inv = target_client['invites'].find('tenant_id' => { '$in' => eu_mixed }).first
+      errors << "invites: #{bad_inv['_id']} belongs to EU tenant #{bad_inv['tenant_id']}" if bad_inv
 
-      # 3. No migrated user may retain EU cache fields (tenant ids/candos).
-      bad_user = target_client['users'].find(
-        '$or' => [
-          { 'tenants_cached' => { '$nin' => [nil, []] } },
-          { 'tenant_candos_cached' => { '$ne' => nil } },
-          { 'tenant_access_group_ids' => { '$nin' => [nil, {}] } }
-        ]
-      ).first
-      errors << "users: #{bad_user['_id']} still has EU cache fields populated" if bad_user
+      # 4. No user on the target may reference an EU tenant in its cached set.
+      bad_user = target_client['users'].find('tenants_cached' => { '$in' => eu_mixed }).first
+      errors << "users: #{bad_user['_id']} caches EU tenant(s)" if bad_user
 
       return true if errors.empty?
 

--- a/lib/apac_migration/leak_guard.rb
+++ b/lib/apac_migration/leak_guard.rb
@@ -35,13 +35,37 @@ module ApacMigration
       bad_inv = target_client['invites'].find('tenant_id' => { '$in' => eu_mixed }).first
       errors << "invites: #{bad_inv['_id']} belongs to EU tenant #{bad_inv['tenant_id']}" if bad_inv
 
-      # 4. No user on the target may reference an EU tenant in its cached set.
+      # 4. No user on the target may reference an EU tenant in any cached field:
+      #    as an element of the tenants_cached array, OR as a KEY of the
+      #    tenant-keyed hashes tenant_access_group_ids / tenant_candos_cached
+      #    ({ tenant_id => … }). Hash keys can't be matched with $in, so those
+      #    two are scanned in Ruby — only over the few users that actually have
+      #    a populated cache hash.
       bad_user = target_client['users'].find('tenants_cached' => { '$in' => eu_mixed }).first
-      errors << "users: #{bad_user['_id']} caches EU tenant(s)" if bad_user
+      bad_user ||= user_caching_eu_hash_key(target_client, eu.map(&:to_s).to_set)
+      errors << "users: #{bad_user['_id']} references an EU tenant in its cache" if bad_user
 
       return true if errors.empty?
 
       raise "APAC LEAK GUARD FAILED:\n - #{errors.join("\n - ")}"
+    end
+
+    private
+
+    # Finds a target user whose tenant-keyed cache hashes contain an EU tenant
+    # id as a key. Only users with a non-empty hash are fetched/scanned.
+    def user_caching_eu_hash_key(target_client, eu_keys)
+      query = { '$or' => [
+        { 'tenant_access_group_ids' => { '$nin' => [nil, {}] } },
+        { 'tenant_candos_cached' => { '$nin' => [nil, {}] } }
+      ] }
+      projection = { 'tenant_access_group_ids' => 1, 'tenant_candos_cached' => 1 }
+      target_client['users'].find(query, projection: projection).find do |doc|
+        keys = []
+        keys.concat(doc['tenant_access_group_ids'].keys) if doc['tenant_access_group_ids'].is_a?(Hash)
+        keys.concat(doc['tenant_candos_cached'].keys) if doc['tenant_candos_cached'].is_a?(Hash)
+        keys.any? { |key| eu_keys.include?(key.to_s) }
+      end
     end
   end
 end

--- a/lib/apac_migration/tenant_set_resolver.rb
+++ b/lib/apac_migration/tenant_set_resolver.rb
@@ -18,6 +18,14 @@ module ApacMigration
       @apac_tenant_ids ||= ((@explicit_ids || Actors::Tenant.apac.pluck(:_id)) + system_tenant_ids).uniq
     end
 
+    # All EU (non-APAC) tenants that exist in the SOURCE. The leak guard uses
+    # this as a blacklist: a target record tied to one of these is a genuine EU
+    # leak — whereas a record created natively on the live APAC cluster (not
+    # present in the source at all) is legitimate and must NOT be flagged.
+    def eu_tenant_ids
+      @eu_tenant_ids ||= Actors::Tenant.unscoped.distinct(:_id) - apac_tenant_ids
+    end
+
     # System tenants required on every cluster regardless of region.
     def system_tenant_ids
       @system_tenant_ids ||= [MDM_TENANT_ID].select do |id|

--- a/lib/tasks/apac_migration.rake
+++ b/lib/tasks/apac_migration.rake
@@ -283,20 +283,26 @@ namespace :apac do
 
     puts "apac:verify (#{Rails.env})"
     puts apac_hr
-    ok = true
+    # Completeness check: every SOURCE doc must exist on the target. Extra docs
+    # on the target are native APAC records (e.g. live signups) — expected on a
+    # live cluster, so they are reported but not a failure.
+    complete = true
     checks.each do |label, (model, selector)|
-      src = model.collection.find(selector).count
-      tgt = target[model.collection.name.to_s].count_documents(selector)
-      match = src == tgt
-      ok &&= match
-      puts "  #{label.ljust(20)} source=#{src}  target=#{tgt}  #{match ? 'OK' : 'MISMATCH'}"
+      src_ids = model.collection.distinct('_id', selector)
+      tgt_ids = target[model.collection.name.to_s].distinct('_id', selector)
+      missing = src_ids - tgt_ids
+      extra   = tgt_ids - src_ids
+      complete &&= missing.empty?
+      note = extra.any? ? "  (+#{extra.size} native on target)" : ''
+      status = missing.empty? ? 'OK' : "MISSING #{missing.size}"
+      puts "  #{label.ljust(18)} source=#{src_ids.size} target=#{tgt_ids.size} #{status}#{note}"
     end
 
     puts '-' * 80
     ApacMigration::LeakGuard.new(resolver).assert!(target)
     puts 'Leak guard passed.'
-    abort 'Count mismatch — see above.' unless ok
-    puts 'Verify OK.'
+    abort 'Incomplete — some source docs are missing on the target (re-run apac:copy).' unless complete
+    puts 'Verify OK (all source docs present on target).'
   end
 
   desc 'Report cross-region dangling refs (does not copy them)'

--- a/spec/lib/apac_migration/leak_guard_spec.rb
+++ b/spec/lib/apac_migration/leak_guard_spec.rb
@@ -6,17 +6,19 @@ RSpec.describe ApacMigration::LeakGuard do
   let(:eu_id) { BSON::ObjectId.new }
   let(:resolver) { instance_double(ApacMigration::TenantSetResolver, eu_tenant_ids: [eu_id]) }
 
-  # Fake Mongo client that actually evaluates simple `{field => {'$in' => [...]}}`
-  # (+ optional scalar equality, e.g. _type) filters against in-memory docs, so
-  # the EU-blacklist behaviour (native APAC records ignored) is really exercised.
+  # Fake Mongo client that evaluates the small query subset the leak guard uses
+  # ($in / $nin / $or / scalar equality) against in-memory docs, so the
+  # EU-blacklist behaviour (native APAC records ignored, EU refs flagged) is
+  # really exercised. #find returns the matched docs (responds to #first and
+  # #find{} like a Mongo::Collection::View).
   def fake_client(actors: [], invites: [], users: [])
     data = { 'actors' => Array.wrap(actors), 'invites' => Array.wrap(invites), 'users' => Array.wrap(users) }
     client = double('target_client')
     allow(client).to receive(:[]) do |name|
       docs = data.fetch(name)
       collection = double("#{name}_collection")
-      allow(collection).to receive(:find) do |query|
-        double(first: docs.find { |doc| matches?(doc, query) })
+      allow(collection).to receive(:find) do |query, _opts = nil|
+        docs.select { |doc| matches?(doc, query) }
       end
       collection
     end
@@ -25,9 +27,13 @@ RSpec.describe ApacMigration::LeakGuard do
 
   def matches?(doc, query)
     query.all? do |field, condition|
-      if condition.is_a?(Hash) && condition.key?('$in')
+      if field == '$or'
+        condition.any? { |sub| matches?(doc, sub) }
+      elsif condition.is_a?(Hash) && condition.key?('$in')
         values = doc[field].is_a?(Array) ? doc[field] : [doc[field]]
         values.any? { |v| condition['$in'].include?(v) }
+      elsif condition.is_a?(Hash) && condition.key?('$nin')
+        !condition['$nin'].include?(doc[field])
       else
         doc[field] == condition
       end
@@ -36,7 +42,11 @@ RSpec.describe ApacMigration::LeakGuard do
 
   it 'passes when only native APAC records are present (no EU tenant refs)' do
     native_map  = { '_id' => BSON::ObjectId.new, '_type' => 'Actors::Mapping', 'tenant_id' => BSON::ObjectId.new }
-    native_user = { '_id' => BSON::ObjectId.new, 'tenants_cached' => [BSON::ObjectId.new] }
+    native_user = {
+      '_id' => BSON::ObjectId.new,
+      'tenants_cached' => [BSON::ObjectId.new],
+      'tenant_access_group_ids' => { BSON::ObjectId.new.to_s => ['g1'] } # native tenant key, not EU
+    }
     expect { described_class.new(resolver).assert!(fake_client(actors: native_map, users: native_user)) }
       .not_to raise_error
   end
@@ -59,8 +69,14 @@ RSpec.describe ApacMigration::LeakGuard do
       .to raise_error(/LEAK GUARD FAILED/i)
   end
 
-  it 'fails on a user caching an EU source tenant' do
+  it 'fails on a user caching an EU source tenant in tenants_cached' do
     leaking = { '_id' => BSON::ObjectId.new, 'tenants_cached' => [eu_id] }
+    expect { described_class.new(resolver).assert!(fake_client(users: leaking)) }
+      .to raise_error(/LEAK GUARD FAILED/i)
+  end
+
+  it 'fails on a user with an EU tenant id as a cache hash KEY' do
+    leaking = { '_id' => BSON::ObjectId.new, 'tenant_access_group_ids' => { eu_id.to_s => ['g1'] } }
     expect { described_class.new(resolver).assert!(fake_client(users: leaking)) }
       .to raise_error(/LEAK GUARD FAILED/i)
   end

--- a/spec/lib/apac_migration/leak_guard_spec.rb
+++ b/spec/lib/apac_migration/leak_guard_spec.rb
@@ -3,40 +3,64 @@ require Rails.root.join('lib/apac_migration/leak_guard')
 require Rails.root.join('lib/apac_migration/tenant_set_resolver')
 
 RSpec.describe ApacMigration::LeakGuard do
-  let(:apac_id) { BSON::ObjectId.new }
-  let(:resolver) { instance_double(ApacMigration::TenantSetResolver, apac_tenant_ids: [apac_id]) }
+  let(:eu_id) { BSON::ObjectId.new }
+  let(:resolver) { instance_double(ApacMigration::TenantSetResolver, eu_tenant_ids: [eu_id]) }
 
-  # Builds a fake Mongo::Client where each collection's #find(...).first
-  # returns the configured offending document (or nil = clean).
-  def fake_client(actors: nil, invites: nil, users: nil)
-    collections = {
-      'actors'  => double(find: double(first: actors)),
-      'invites' => double(find: double(first: invites)),
-      'users'   => double(find: double(first: users))
-    }
-    double('target_client').tap do |client|
-      allow(client).to receive(:[]) { |name| collections.fetch(name) }
+  # Fake Mongo client that actually evaluates simple `{field => {'$in' => [...]}}`
+  # (+ optional scalar equality, e.g. _type) filters against in-memory docs, so
+  # the EU-blacklist behaviour (native APAC records ignored) is really exercised.
+  def fake_client(actors: [], invites: [], users: [])
+    data = { 'actors' => Array.wrap(actors), 'invites' => Array.wrap(invites), 'users' => Array.wrap(users) }
+    client = double('target_client')
+    allow(client).to receive(:[]) do |name|
+      docs = data.fetch(name)
+      collection = double("#{name}_collection")
+      allow(collection).to receive(:find) do |query|
+        double(first: docs.find { |doc| matches?(doc, query) })
+      end
+      collection
+    end
+    client
+  end
+
+  def matches?(doc, query)
+    query.all? do |field, condition|
+      if condition.is_a?(Hash) && condition.key?('$in')
+        values = doc[field].is_a?(Array) ? doc[field] : [doc[field]]
+        values.any? { |v| condition['$in'].include?(v) }
+      else
+        doc[field] == condition
+      end
     end
   end
 
-  it 'passes when nothing leaks' do
-    expect { described_class.new(resolver).assert!(fake_client) }.not_to raise_error
+  it 'passes when only native APAC records are present (no EU tenant refs)' do
+    native_map  = { '_id' => BSON::ObjectId.new, '_type' => 'Actors::Mapping', 'tenant_id' => BSON::ObjectId.new }
+    native_user = { '_id' => BSON::ObjectId.new, 'tenants_cached' => [BSON::ObjectId.new] }
+    expect { described_class.new(resolver).assert!(fake_client(actors: native_map, users: native_user)) }
+      .not_to raise_error
   end
 
-  it 'fails on a mapping with a non-APAC tenant_id' do
-    leaking = { '_id' => BSON::ObjectId.new, 'tenant_id' => BSON::ObjectId.new }
+  it 'fails on a mapping pointing at an EU source tenant' do
+    leaking = { '_id' => BSON::ObjectId.new, '_type' => 'Actors::Mapping', 'tenant_id' => eu_id }
     expect { described_class.new(resolver).assert!(fake_client(actors: leaking)) }
       .to raise_error(/LEAK GUARD FAILED/i)
   end
 
-  it 'fails on an invite with a non-APAC tenant_id' do
-    leaking = { '_id' => BSON::ObjectId.new, 'tenant_id' => BSON::ObjectId.new.to_s }
+  it 'fails on an EU source tenant present on the target' do
+    leaking = { '_id' => eu_id, '_type' => 'Actors::Tenant' }
+    expect { described_class.new(resolver).assert!(fake_client(actors: leaking)) }
+      .to raise_error(/LEAK GUARD FAILED/i)
+  end
+
+  it 'fails on an invite belonging to an EU source tenant (string form)' do
+    leaking = { '_id' => BSON::ObjectId.new, 'tenant_id' => eu_id.to_s }
     expect { described_class.new(resolver).assert!(fake_client(invites: leaking)) }
       .to raise_error(/LEAK GUARD FAILED/i)
   end
 
-  it 'fails on a user that still carries EU cache fields' do
-    leaking = { '_id' => BSON::ObjectId.new, 'tenants_cached' => [BSON::ObjectId.new] }
+  it 'fails on a user caching an EU source tenant' do
+    leaking = { '_id' => BSON::ObjectId.new, 'tenants_cached' => [eu_id] }
     expect { described_class.new(resolver).assert!(fake_client(users: leaking)) }
       .to raise_error(/LEAK GUARD FAILED/i)
   end


### PR DESCRIPTION
Follow-up to #260. Once the APAC cluster is live and accepting native signups/logins, it legitimately accumulates records that are **not** part of the migration set. The previous whitelist-based safety checks ("everything on the target must be in the APAC set") then false-alarmed on that native data — both `apac:copy`'s leak guard and `apac:verify` aborted on records created by test logins / `db:seed` on the live APAC cluster.

This switches both checks to the correct invariant.

## Changes
- **Leak guard** now flags by an **EU-source-tenant blacklist** (`tenant_id ∈ source EU tenants`) instead of the APAC whitelist. Records created natively on the live APAC cluster (not present in the source) are correctly ignored; genuine EU leaks still fail loudly. Covers mappings, tenants, invites and cached tenant refs on users.
- **`tenant_set_resolver`** gains `eu_tenant_ids` (all source tenants minus the APAC set) backing the blacklist.
- **`apac:verify`** checks **completeness** (every source `_id` present on the target) instead of exact count equality. Extra native target docs are reported as `(+N native on target)`; the task fails only when source docs are actually **missing**.
- **Spec**: the fake Mongo client now evaluates `$in`, so the EU-vs-native distinction is genuinely exercised.

## Verification
- `bundle exec rspec spec/lib/apac_migration` → 13 examples, 0 failures
- rubocop clean (only the intentional `puts`/`abort` in the rake/CLI tooling remain, consistent with `lib/tasks/app.rake`)
- On the live APAC target: `apac:verify` now reports `OK (+58 native on target)` and `Leak guard passed` instead of aborting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)