### PR TITLE
APAC migration: copy the app-level skeleton (fixes login on target)

### DIFF
--- a/docs/apac_migration.md
+++ b/docs/apac_migration.md
@@ -135,6 +135,7 @@ authoritative. (SCB unlocks its tenants.)
 | Actors::User nodes (`actors`) | `actor_id` of migrated users | personal nodes live in the global `user_container` |
 | Invites (`invites`) | `tenant_id ∈ apac_ids` | |
 | Global reference data | `roles`, `functionalities`, `contents` | no identity data; copied whole so group `role_ids` resolve on target |
+| Migration tracking | `data_migrations` (mongoid_rails_migrations) | copied whole so the target treats historical migrations as already run and does **not** replay them on first boot (which would re-run e.g. index/role migrations against copied data and can crash) |
 | S3 objects (`apac:copy_s3`) | image_data keys of migrated actors + users | tenant logos / actor images + user avatars (Shrine, `uploads/<class>/<id>/...`) |
 
 **Deliberately NOT copied:** `account_activities` (audit/login-IP log, regenerates),

--- a/docs/apac_migration.md
+++ b/docs/apac_migration.md
@@ -129,6 +129,7 @@ authoritative. (SCB unlocks its tenants.)
 | Tenant subtree (`actors`) | `_id ∈ apac_ids` ∪ `parent_ids ∈ apac_ids` | tenants + Organization/Ou/Group/**Mapping**; every Mapping here is APAC by definition |
 | Structural ancestors (`actors`) | `parent_ids` of the subtree + user nodes | App + ContainerApps/ContainerTenants/ContainerUsers, **id-preserving** — needed so the tree, paths and roles' `actors_app_id` resolve. App skeleton/config only, no tenant identity, no sibling tenants. |
 | App definitions (`actors`) | `_type == Actors::App` (wholesale) | all App nodes incl. the identity-management base app; skeleton/config only |
+| App skeleton (`actors`) | direct children of each App + app Organization subtree, minus Tenants/Mappings | app "users"/app-admins/tenant-admins groups, containers, app OUs — needed for app flows like `ensure_app_membership!` on login. No tenant identity data. |
 | System records | MDM tenant (`samedis-care`, region nil) + `global_admin` (User **and** Actors::User) | always copied regardless of region — required on every cluster. The MDM subtree brings the master-data structure and global_admin's MDM-scoped mappings. |
 | User identities (`users`) | users with ≥1 APAC mapping | identity (email/name/pw) travels; **EU cache fields cleared** on copy |
 | Actors::User nodes (`actors`) | `actor_id` of migrated users | personal nodes live in the global `user_container` |

--- a/lib/apac_migration/collection_registry.rb
+++ b/lib/apac_migration/collection_registry.rb
@@ -14,7 +14,8 @@ module ApacMigration
       'invites'         => 'tenant_id ∈ apac',
       'roles'           => 'global app reference data (no identity data); copied so role_ids match',
       'functionalities' => 'global app reference data (no identity data)',
-      'contents'        => 'global app reference data (no identity data)'
+      'contents'        => 'global app reference data (no identity data)',
+      'data_migrations' => 'mongoid_rails_migrations tracking; copied so the target does not replay migrations'
     }.freeze
 
     # Tenant-scoped or identity-adjacent collections deliberately NOT copied.

--- a/lib/apac_migration/tenant_set_resolver.rb
+++ b/lib/apac_migration/tenant_set_resolver.rb
@@ -18,6 +18,25 @@ module ApacMigration
       @apac_tenant_ids ||= ((@explicit_ids || Actors::Tenant.apac.pluck(:_id)) + system_tenant_ids).uniq
     end
 
+    # App-level skeleton actors below each App: its direct children (containers,
+    # the app "users" Group used by ensure_app_membership!, app-admins /
+    # tenant-admins groups, the app Organization) plus everything under the app
+    # Organization. Excludes Tenants (copied separately) and Mappings (per-user;
+    # would reference non-migrated EU users). These are app structure only — no
+    # tenant identity data — needed for app-level flows (login → app membership)
+    # to work on the target.
+    def app_skeleton_ids
+      @app_skeleton_ids ||= begin
+        apps = app_actor_ids
+        org_ids = Actor.unscoped.where(:parent_id.in => apps, _type: 'Actors::Organization').distinct(:_id)
+        ids  = Actor.unscoped.where(:parent_id.in => apps)
+                    .where(:_type.nin => %w[Actors::Tenant Actors::Mapping]).distinct(:_id)
+        ids += Actor.unscoped.where(:parent_ids.in => org_ids)
+                    .where(:_type.nin => %w[Actors::Mapping]).distinct(:_id)
+        ids.uniq
+      end
+    end
+
     # All EU (non-APAC) tenants that exist in the SOURCE. The leak guard uses
     # this as a blacklist: a target record tied to one of these is a genuine EU
     # leak — whereas a record created natively on the live APAC cluster (not

--- a/lib/tasks/apac_migration.rake
+++ b/lib/tasks/apac_migration.rake
@@ -189,6 +189,9 @@ namespace :apac do
     copier.copy(model: Role,          selector: {}, label: 'roles',           deltaable: false)
     copier.copy(model: Functionality, selector: {}, label: 'functionalities', deltaable: false)
     copier.copy(model: Content,       selector: {}, label: 'contents',        deltaable: false)
+    # 6. Migration tracking (mongoid_rails_migrations) — so the target treats all
+    #    historical migrations as already run and does not replay them on boot.
+    copier.copy(model: DataMigration, selector: {}, label: 'data_migrations', deltaable: false)
 
     puts '-' * 80
     if dry

--- a/lib/tasks/apac_migration.rake
+++ b/lib/tasks/apac_migration.rake
@@ -174,6 +174,10 @@ namespace :apac do
     # 1c. All App definition nodes (incl. the identity-management base app).
     copier.copy(model: Actor, selector: { '_type' => 'Actors::App' },
                 label: 'actors (apps)', deltaable: false)
+    # 1d. App-level skeleton (app "users"/app-admins groups, organization, OUs,
+    #     containers) so app flows like ensure_app_membership! work on target.
+    copier.copy(model: Actor, selector: { '_id' => { '$in' => resolver.app_skeleton_ids } },
+                label: 'actors (app skeleton)', deltaable: false)
     # 2. Personal Actors::User nodes of migrated users (live in user_container)
     copier.copy(model: Actor, selector: { '_id' => { '$in' => resolver.actor_user_ids } }, label: 'actors (user nodes)')
     # 3. User identities — EU cache fields stripped on copy


### PR DESCRIPTION
Follow-up to #260 / #261.

## Problem
Microsoft/Apple login on the APAC target raised:
```
NoMethodError: undefined method 'map_into!' for nil
  app/models/user.rb:597  User#ensure_app_membership!
  _app.app_container_users.map_into!(actor, {}, cache_expire: false)
```
`app_container_users` is a **Group named `users` that is a direct child of the App** (`app/models/actors/app.rb:247`), not a container. Like the other app-level structural nodes (app-admins / tenant-admins groups, the app Organization, containers) it is neither an ancestor of an APAC tenant nor a parent of a migrated user node, so none of the existing copy selections picked it up — it was missing on the target and `app_container_users` returned `nil`.

## Fix
- **resolver**: `app_skeleton_ids` — each App's direct children plus the app Organization subtree, **excluding** `Actors::Tenant` (copied separately) and `Actors::Mapping` (per-user; would reference non-migrated EU users). App structure only, no tenant identity data.
- **copy**: new `actors (app skeleton)` step (id-preserving, `deltaable: false`).
- **docs**: document the app-skeleton set.

## Verification
- Read-only against the **live source**: both apps' `users` and `admins` groups are in the set; **0 tenants, 0 mappings, 0 EU-tenant-scoped nodes** — no leak.
- On the target after re-running `apac:copy`: both apps now resolve their `users` group (`samedis-care` → `5d39bef0534e67000900e701`, `identity-management` → `62ea9956d67ac100012ad255`), with the **original source ids preserved**.
- `bundle exec rspec spec/lib/apac_migration` → 14 examples, 0 failures; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)