### PR TITLE
security: tenant-scope authorization across all tenant-nested endpoints

### DIFF
--- a/app/controllers/api/v1/access_control/tenant/profiles_controller.rb
+++ b/app/controllers/api/v1/access_control/tenant/profiles_controller.rb
@@ -18,6 +18,11 @@ class Api::V1::AccessControl::Tenant::ProfilesController < Api::V1::JsonApiContr
     action_suffix: 'Custom profiles'
   }.freeze
 
+  # Tenant-scoped authorization — own-tenant only, matching the sibling
+  # access_control/tenant/{users,groups} controllers (security audit H-6).
+  skip_before_action :authorize
+  before_action :tenant_authorize
+
   PERMIT_CREATE = [
     :title,
     :name,

--- a/app/controllers/api/v1/access_control/tenant/roles_controller.rb
+++ b/app/controllers/api/v1/access_control/tenant/roles_controller.rb
@@ -13,6 +13,11 @@ class Api::V1::AccessControl::Tenant::RolesController < Api::V1::JsonApiControll
 
   SWAGGER = { tag: 'Access Control', name: 'Tenant Role', header: 'Manage roles within tenant access control' }
 
+  # Tenant-scoped authorization — own-tenant only, matching the sibling
+  # access_control/tenant/{users,groups} controllers (security audit M-9).
+  skip_before_action :authorize
+  before_action :tenant_authorize
+
   undef_method :create
   undef_method :update
   undef_method :destroy

--- a/app/controllers/api/v1/apps/tenants/organizations/actor_roles_controller.rb
+++ b/app/controllers/api/v1/apps/tenants/organizations/actor_roles_controller.rb
@@ -12,7 +12,24 @@ class Api::V1::Apps::Tenants::Organizations::ActorRolesController < Api::V1::Jso
 
   PERMIT_CREATE = [:role_id]
 
-  SWAGGER = { tag: 'Tenant Org Roles', name: 'Organization Role', header: 'Manage roles within a tenant organization' }
+  SWAGGER = {
+    tag: 'Tenant Org Roles',
+    name: 'Organization Role',
+    header: 'Manage roles within a tenant organization'
+  }
+
+  # SECURITY / pen-test note (2026-07):
+  # Admin-only endpoint. Access is intentionally gated to ~/app-tenant.admin,
+  # which is an APP-WIDE (cross-tenant) admin cando by design — hence the global
+  # `authorize` (not tenant_authorize) is correct here.
+  # ~/tenant.admin was deliberately REMOVED from the cando list: it is a
+  # per-tenant cando bundled into ordinary customer roles (e.g. "Edit facility
+  # data"), and combined with the global cando check it let a plain tenant admin
+  # assign themselves privileged roles (incl. apps.admin) -> privilege
+  # escalation. Do not re-add ~/tenant.admin here.
+  # NOTE: an app-tenant.admin can still assign any app role to any actor
+  # (Actor.find/role lookups are unscoped); that is accepted as a trusted-admin
+  # capability. Keep app-tenant.admin restricted to trusted operators.
 
   undef_method :update
 
@@ -61,10 +78,10 @@ class Api::V1::Apps::Tenants::Organizations::ActorRolesController < Api::V1::Jso
 
   def cando
     CANDO.merge({
-      show:    %w(~/app-tenant.admin ~/tenant.admin),
-      index:   %w(~/app-tenant.admin ~/tenant.admin),
-      create:  %w(~/app-tenant.admin ~/tenant.admin),
-      destroy: %w(~/app-tenant.admin ~/tenant.admin)
+      show:    %w(~/app-tenant.admin),
+      index:   %w(~/app-tenant.admin),
+      create:  %w(~/app-tenant.admin),
+      destroy: %w(~/app-tenant.admin)
     })
   end
 

--- a/app/controllers/api/v1/apps/tenants/organizations/mappings_controller.rb
+++ b/app/controllers/api/v1/apps/tenants/organizations/mappings_controller.rb
@@ -13,7 +13,21 @@ class Api::V1::Apps::Tenants::Organizations::MappingsController < Api::V1::JsonA
 
   PERMIT_CREATE = [:map_actor_id, :user_id]
 
-  SWAGGER = { tag: 'Tenant Org Mappings', name: 'Mapping', header: 'User-to-organization mappings within a tenant' }
+  SWAGGER = {
+    tag: 'Tenant Org Mappings',
+    name: 'Mapping',
+    header: 'User-to-organization mappings within a tenant'
+  }.freeze
+
+  # SECURITY / pen-test note (2026-07):
+  # Admin-only endpoint. Gated to ~/app-tenant.admin, which is an APP-WIDE
+  # (cross-tenant) admin cando by design — the global `authorize` is correct.
+  # ~/tenant.admin was deliberately REMOVED (it is a per-tenant cando bundled
+  # into ordinary customer roles) to prevent a per-tenant admin from mapping
+  # actors into arbitrary tenant groups. Do not re-add ~/tenant.admin.
+  # create/destroy run through the scoped MODEL (Actors::Mapping.where(parent:
+  # _parent)), where _parent is resolved within this tenant's org subtree, so
+  # the mapping target group is already tenant-scoped.
 
   undef_method :update
 
@@ -24,10 +38,10 @@ class Api::V1::Apps::Tenants::Organizations::MappingsController < Api::V1::JsonA
 
   def cando
     CANDO.merge({
-      show:    %w(~/app-tenant.admin ~/tenant.admin),
-      index:   %w(~/app-tenant.admin ~/tenant.admin),
-      create:  %w(~/app-tenant.admin ~/tenant.admin),
-      destroy: %w(~/app-tenant.admin ~/tenant.admin)
+      show:    %w(~/app-tenant.admin),
+      index:   %w(~/app-tenant.admin),
+      create:  %w(~/app-tenant.admin),
+      destroy: %w(~/app-tenant.admin)
     })
   end
 

--- a/app/controllers/api/v1/apps/tenants/organizations/picker/mappable_users_controller.rb
+++ b/app/controllers/api/v1/apps/tenants/organizations/picker/mappable_users_controller.rb
@@ -35,9 +35,12 @@ class Api::V1::Apps::Tenants::Organizations::Picker::MappableUsersController < A
     end
   end
 
+  # SECURITY (pen-test 2026-07): internal-admin-only. ~/tenant.admin intentionally
+  # excluded — it is a per-tenant customer cando; app-tenant.admin is app-wide by
+  # design, so the global authorize is correct here. Do not re-add ~/tenant.admin.
   def cando
     CANDO.merge({
-      index:   %w(~/app-tenant.admin ~/tenant.admin)
+      index:   %w(~/app-tenant.admin)
     })
   end
 

--- a/app/controllers/api/v1/apps/tenants/organizations_controller.rb
+++ b/app/controllers/api/v1/apps/tenants/organizations_controller.rb
@@ -41,13 +41,16 @@ class Api::V1::Apps::Tenants::OrganizationsController < Api::V1::JsonApiControll
     super+[:organization_id]
   end
 
+  # SECURITY (pen-test 2026-07): internal-admin-only. ~/tenant.admin intentionally
+  # excluded — it is a per-tenant customer cando; app-tenant.admin is app-wide by
+  # design, so the global authorize is correct here. Do not re-add ~/tenant.admin.
   def cando
     CANDO.merge({
-      show:    %w(~/app-tenant.admin ~/tenant.admin),
-      index:   %w(~/app-tenant.admin ~/tenant.admin),
-      create:  %w(~/app-tenant.admin ~/tenant.admin),
-      update:  %w(~/app-tenant.admin ~/tenant.admin),
-      destroy: %w(~/app-tenant.admin ~/tenant.admin)
+      show:    %w(~/app-tenant.admin),
+      index:   %w(~/app-tenant.admin),
+      create:  %w(~/app-tenant.admin),
+      update:  %w(~/app-tenant.admin),
+      destroy: %w(~/app-tenant.admin)
     })
   end
 

--- a/app/controllers/api/v1/apps/tenants/organizations_tree_controller.rb
+++ b/app/controllers/api/v1/apps/tenants/organizations_tree_controller.rb
@@ -38,10 +38,13 @@ class Api::V1::Apps::Tenants::OrganizationsTreeController < Api::V1::JsonApiCont
     super+[:organization_id]
   end
 
+  # SECURITY (pen-test 2026-07): internal-admin-only. ~/tenant.admin intentionally
+  # excluded — it is a per-tenant customer cando; app-tenant.admin is app-wide by
+  # design, so the global authorize is correct here. Do not re-add ~/tenant.admin.
   def cando
     CANDO.merge({
-      show:    %w(~/app-tenant.admin ~/tenant.admin),
-      index:   %w(~/app-tenant.admin ~/tenant.admin)
+      show:    %w(~/app-tenant.admin),
+      index:   %w(~/app-tenant.admin)
     })
   end
 

--- a/app/controllers/api/v1/apps/tenants/picker/mappable_users_controller.rb
+++ b/app/controllers/api/v1/apps/tenants/picker/mappable_users_controller.rb
@@ -18,9 +18,12 @@ class Api::V1::Apps::Tenants::Picker::MappableUsersController < Api::V1::JsonApi
   undef_method :destroy
 
   private
+  # SECURITY (pen-test 2026-07): internal-admin-only. ~/tenant.admin intentionally
+  # excluded — it is a per-tenant customer cando; app-tenant.admin is app-wide by
+  # design, so the global authorize is correct here. Do not re-add ~/tenant.admin.
   def cando
     CANDO.merge({
-      index:   %w(~/app-tenant.admin ~/tenant.admin)
+      index:   %w(~/app-tenant.admin)
     })
   end
 

--- a/app/controllers/api/v1/apps/tenants/picker/user_organization_controller.rb
+++ b/app/controllers/api/v1/apps/tenants/picker/user_organization_controller.rb
@@ -14,10 +14,13 @@ class Api::V1::Apps::Tenants::Picker::UserOrganizationController < Api::V1::Json
   undef_method :update
   undef_method :destroy
 
+  # SECURITY (pen-test 2026-07): internal-admin-only. ~/tenant.admin intentionally
+  # excluded — it is a per-tenant customer cando; app-tenant.admin is app-wide by
+  # design, so the global authorize is correct here. Do not re-add ~/tenant.admin.
   def cando
     CANDO.merge({
-      index:   %w(~/app-tenant.admin ~/tenant.admin),
-      show:    %w(~/app-tenant.admin ~/tenant.admin)
+      index:   %w(~/app-tenant.admin),
+      show:    %w(~/app-tenant.admin)
     })
   end
 

--- a/app/controllers/api/v1/apps/tenants/users/actors_controller.rb
+++ b/app/controllers/api/v1/apps/tenants/users/actors_controller.rb
@@ -2,7 +2,8 @@ class Api::V1::Apps::Tenants::Users::ActorsController < Api::V1::Apps::Users::Us
 
   MODEL_BASE = Actors::Mapping
   MODEL = -> {
-    current_app_actor.tenants.find(params_json_api[:tenant_id]).descendants.where(:id.in => mappings.distinct(:parent_id))
+    current_app_actor.tenants.find(params_json_api[:tenant_id])
+      .descendants.where(:id.in => mappings.distinct(:parent_id))
   }
   MODEL_OVERVIEW = MODEL
   SERIALIZER = UserOrganizationSerializer
@@ -10,7 +11,21 @@ class Api::V1::Apps::Tenants::Users::ActorsController < Api::V1::Apps::Users::Us
 
   PERMIT_UPDATE = []
 
-  SWAGGER = { tag: 'Tenant User Actors', name: 'Actor', header: 'Actor mappings for a tenant user' }
+  SWAGGER = {
+    tag: 'Tenant User Actors',
+    name: 'Actor',
+    header: 'Actor mappings for a tenant user'
+  }.freeze
+
+  # SECURITY / pen-test note (2026-07):
+  # Admin-only endpoint. Gated to ~/app-tenant.admin, an APP-WIDE (cross-tenant)
+  # admin cando by design — the global `authorize` is correct.
+  # ~/tenant.admin was deliberately REMOVED (per-tenant cando bundled into
+  # ordinary customer roles) to prevent a per-tenant admin from mapping users
+  # into arbitrary actors. Do not re-add ~/tenant.admin.
+  # NOTE: #create resolves actor_id / target_user app-wide (not tenant-scoped);
+  # that is accepted as a trusted-admin capability. Keep app-tenant.admin
+  # restricted to trusted operators.
 
   undef_method :update
 
@@ -47,10 +62,10 @@ class Api::V1::Apps::Tenants::Users::ActorsController < Api::V1::Apps::Users::Us
 
   def cando
     CANDO.merge({
-                  show:    %w(~/app-tenant.admin ~/tenant.admin),
-                  index:   %w(~/app-tenant.admin ~/tenant.admin),
-                  create:  %w(~/app-tenant.admin ~/tenant.admin),
-                  destroy: %w(~/app-tenant.admin ~/tenant.admin),
+                  show:    %w(~/app-tenant.admin),
+                  index:   %w(~/app-tenant.admin),
+                  create:  %w(~/app-tenant.admin),
+                  destroy: %w(~/app-tenant.admin),
                 })
   end
 

--- a/app/controllers/api/v1/apps/tenants/users/functionalities_controller.rb
+++ b/app/controllers/api/v1/apps/tenants/users/functionalities_controller.rb
@@ -17,10 +17,13 @@ class Api::V1::Apps::Tenants::Users::FunctionalitiesController < Api::V1::Apps::
   undef_method :destroy
 
   private
+  # SECURITY (pen-test 2026-07): internal-admin-only. ~/tenant.admin intentionally
+  # excluded — it is a per-tenant customer cando; app-tenant.admin is app-wide by
+  # design, so the global authorize is correct here. Do not re-add ~/tenant.admin.
   def cando
     CANDO.merge({
-                  show:    %w(~/app-tenant.admin ~/tenant.admin),
-                  index:   %w(~/app-tenant.admin ~/tenant.admin)
+                  show:    %w(~/app-tenant.admin),
+                  index:   %w(~/app-tenant.admin)
                 })
   end
 

--- a/app/controllers/api/v1/apps/tenants/users/roles_controller.rb
+++ b/app/controllers/api/v1/apps/tenants/users/roles_controller.rb
@@ -17,10 +17,13 @@ class Api::V1::Apps::Tenants::Users::RolesController < Api::V1::Apps::Users::Use
   undef_method :destroy
 
   private
+  # SECURITY (pen-test 2026-07): internal-admin-only. ~/tenant.admin intentionally
+  # excluded — it is a per-tenant customer cando; app-tenant.admin is app-wide by
+  # design, so the global authorize is correct here. Do not re-add ~/tenant.admin.
   def cando
     CANDO.merge({
-                  show:    %w(~/app-tenant.admin ~/tenant.admin),
-                  index:   %w(~/app-tenant.admin ~/tenant.admin)
+                  show:    %w(~/app-tenant.admin),
+                  index:   %w(~/app-tenant.admin)
                 })
   end
 

--- a/app/controllers/api/v1/apps/tenants/users_controller.rb
+++ b/app/controllers/api/v1/apps/tenants/users_controller.rb
@@ -1,5 +1,11 @@
 class Api::V1::Apps::Tenants::UsersController < Api::V1::JsonApiController
 
+  # Tenant-scoped authorization: the required cando must be held IN the target
+  # tenant (current_tenant is membership-scoped). Prevents a tenant.admin of one
+  # tenant from acting on users of another tenant. See security audit C-1.
+  skip_before_action :authorize
+  before_action :tenant_authorize
+
   MODEL_BASE = User
   MODEL = -> {
     current_tenant_actor.users.available

--- a/app/controllers/api/v1/apps/tenants/users_controller.rb
+++ b/app/controllers/api/v1/apps/tenants/users_controller.rb
@@ -1,11 +1,5 @@
 class Api::V1::Apps::Tenants::UsersController < Api::V1::JsonApiController
 
-  # Tenant-scoped authorization: the required cando must be held IN the target
-  # tenant (current_tenant is membership-scoped). Prevents a tenant.admin of one
-  # tenant from acting on users of another tenant. See security audit C-1.
-  skip_before_action :authorize
-  before_action :tenant_authorize
-
   MODEL_BASE = User
   MODEL = -> {
     current_tenant_actor.users.available
@@ -34,6 +28,12 @@ class Api::V1::Apps::Tenants::UsersController < Api::V1::JsonApiController
   ]
 
   SWAGGER = { tag: 'Tenant Users', name: 'User', header: 'Manage users within a tenant of an app' }
+
+  # Tenant-scoped authorization: the required cando must be held IN the target
+  # tenant (current_tenant is membership-scoped). Prevents a tenant.admin of one
+  # tenant from acting on users of another tenant. See security audit C-1.
+  skip_before_action :authorize
+  before_action :tenant_authorize
 
   undef_method :create
   undef_method :destroy

--- a/app/controllers/api/v1/json_api_controller.rb
+++ b/app/controllers/api/v1/json_api_controller.rb
@@ -383,6 +383,7 @@ class Api::V1::JsonApiController < ApplicationController
 
   def tenant_authorize
     return if performed?
+    return render_jsonapi_otp_required unless current_token.otp_satisfied?
     render_jsonapi_unauthorized unless tenant_authorization
   end
 

--- a/app/controllers/api/v1/picker/tenant_users_controller.rb
+++ b/app/controllers/api/v1/picker/tenant_users_controller.rb
@@ -8,7 +8,17 @@ class Api::V1::Picker::TenantUsersController < Api::V1::JsonApiController
 
   PARAM_UPDATE = [tenant_groups: []]
 
-  SWAGGER = { tag: 'Picker: Tenant Users', name: 'Tenant User', header: 'Tenant user picker for selection dialogs' }
+  SWAGGER = {
+    tag: 'Picker: Tenant Users',
+    name: 'Tenant User',
+    header: 'Tenant user picker for selection dialogs'
+  }
+
+  # Tenant-scoped authorization — own-tenant only, matching the
+  # access_control/tenant/* controllers: the cando must be held IN the target
+  # tenant, not merely somewhere in the user's global candos (security audit).
+  skip_before_action :authorize
+  before_action :tenant_authorize
 
   undef_method :create
   undef_method :destroy

--- a/spec/controllers/api/v1/tenant_scoped_authorization_spec.rb
+++ b/spec/controllers/api/v1/tenant_scoped_authorization_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'tenant-scoped controller authorization', type: :model do
   TENANT_SCOPED_CONTROLLERS = [
     Api::V1::Apps::Tenants::UsersController,
     Api::V1::AccessControl::Tenant::ProfilesController,
-    Api::V1::AccessControl::Tenant::RolesController
+    Api::V1::AccessControl::Tenant::RolesController,
+    Api::V1::Picker::TenantUsersController
   ].freeze
 
   def before_filters(controller)

--- a/spec/controllers/api/v1/tenant_scoped_authorization_spec.rb
+++ b/spec/controllers/api/v1/tenant_scoped_authorization_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+# Regression guard for the cross-tenant authorization fix (security audit C-1).
+#
+# Api::V1::Apps::Tenants::UsersController scopes its data by a tenant taken from
+# the request path (params[:tenant_id]) and allows updating users (incl.
+# set_password). It MUST authorize per-tenant via `tenant_authorize` (which
+# checks the required cando against current_tenant — the tenant the current_user
+# is actually a MEMBER of). It must NOT use the default `authorize`, which
+# evaluates the cando against User#global_candos (the union across ALL tenants)
+# and therefore lets a tenant.admin of one tenant act on every other tenant.
+RSpec.describe Api::V1::Apps::Tenants::UsersController, type: :model do
+  def before_filters(controller)
+    controller._process_action_callbacks
+              .select { |c| c.kind == :before }
+              .map(&:filter)
+  end
+
+  it 'authorizes per-tenant via :tenant_authorize' do
+    expect(before_filters(described_class)).to include(:tenant_authorize)
+  end
+
+  it 'does not fall back to the global :authorize' do
+    expect(before_filters(described_class)).not_to include(:authorize)
+  end
+end

--- a/spec/controllers/api/v1/tenant_scoped_authorization_spec.rb
+++ b/spec/controllers/api/v1/tenant_scoped_authorization_spec.rb
@@ -1,26 +1,36 @@
 require 'rails_helper'
 
-# Regression guard for the cross-tenant authorization fix (security audit C-1).
+# Regression guard for the cross-tenant authorization fix (security audit C-1/H-6/M-9).
 #
-# Api::V1::Apps::Tenants::UsersController scopes its data by a tenant taken from
-# the request path (params[:tenant_id]) and allows updating users (incl.
-# set_password). It MUST authorize per-tenant via `tenant_authorize` (which
-# checks the required cando against current_tenant — the tenant the current_user
-# is actually a MEMBER of). It must NOT use the default `authorize`, which
-# evaluates the cando against User#global_candos (the union across ALL tenants)
-# and therefore lets a tenant.admin of one tenant act on every other tenant.
-RSpec.describe Api::V1::Apps::Tenants::UsersController, type: :model do
+# These controllers scope their data by a tenant taken from the request path
+# (params[:tenant_id]). They MUST authorize per-tenant via `tenant_authorize`
+# (which checks the required cando against current_tenant — the tenant the
+# current_user is actually a MEMBER of). They must NOT use the default
+# `authorize`, which evaluates the cando against User#global_candos — the union
+# of a user's candos across ALL tenants — and therefore lets a tenant.admin of
+# one tenant act on every other tenant.
+RSpec.describe 'tenant-scoped controller authorization', type: :model do
+  TENANT_SCOPED_CONTROLLERS = [
+    Api::V1::Apps::Tenants::UsersController,
+    Api::V1::AccessControl::Tenant::ProfilesController,
+    Api::V1::AccessControl::Tenant::RolesController
+  ].freeze
+
   def before_filters(controller)
     controller._process_action_callbacks
               .select { |c| c.kind == :before }
               .map(&:filter)
   end
 
-  it 'authorizes per-tenant via :tenant_authorize' do
-    expect(before_filters(described_class)).to include(:tenant_authorize)
-  end
+  TENANT_SCOPED_CONTROLLERS.each do |controller|
+    describe controller.name do
+      it 'authorizes per-tenant via :tenant_authorize' do
+        expect(before_filters(controller)).to include(:tenant_authorize)
+      end
 
-  it 'does not fall back to the global :authorize' do
-    expect(before_filters(described_class)).not_to include(:authorize)
+      it 'does not fall back to the global :authorize' do
+        expect(before_filters(controller)).not_to include(:authorize)
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes the Broken Access Control gaps (OWASP A01) on every tenant-nested IM endpoint, where a per-tenant cando (`tenant.admin`, `access-control.*`, `list-tenant-users.*`) was checked against the caller's **global** candos (union across all tenants) while the target tenant came from `params[:tenant_id]`.

### Verified (local_dev)
Users holding **only** `tenant.admin` (no app-wide cando), members of their own tenant(s), were granted by `authorize()` on a **foreign** tenant (zero candos there), target `m.schiffner@sana-mtsz.de`:
```
authorize() ACTUAL (global_candos) => true    CORRECT per-tenant => false
```
`apps/tenants/users` permits `:set_password` → cross-tenant account takeover. 2,212 external users hold `tenant.admin`.

## Two fix patterns, per endpoint intent

**A) Own-tenant self-service → `tenant_authorize`** (cando checked against a tenant the user is a MEMBER of; `tenant.admin` still works, but only for the user's own tenant):
- `apps/tenants/users` (C-1 — the account-takeover path)
- `access_control/tenant/profiles` (H-6), `access_control/tenant/roles` (M-9) — matching sibling `access_control/tenant/{users,groups}`
- `picker/tenant/users` / ident_accounts
- `json_api_controller`: `tenant_authorize` now also enforces the OTP gate (closes a latent MFA gap)

**B) Internal-admin-only → drop `~/tenant.admin`, gate to app-wide `~/app-tenant.admin`** (global `authorize` intentional; these are not customer surfaces):
- `apps/tenants/organizations/actor_roles` (C-2 — privilege escalation)
- `apps/tenants/organizations/mappings` (C-3), `apps/tenants/users/actors` (C-3)
- `apps/tenants/organizations`, `apps/tenants/organizations_tree`
- `apps/tenants/users/roles`, `apps/tenants/users/functionalities`
- `apps/tenants/organizations/picker/mappable_users`, `apps/tenants/picker/mappable_users`, `apps/tenants/picker/user_organization`

Every touched controller carries an inline SECURITY / pen-test note explaining the intent, so the choice reads as deliberate at the next review. Regression guard spec covers the `tenant_authorize` set (8 examples, green).

## Residual (accepted / to verify on prod)
`app-tenant.admin` is a trusted app-wide admin cando and remains able to assign/administer across tenants — keep it restricted to trusted operators; verify holders on prod (in local_dev: internal + the maintainer's own accounts).

## Testing
- `rspec spec/controllers/api/v1/tenant_scoped_authorization_spec.rb` → 8 examples, 0 failures.
- Smoke: every changed controller loads (`ruby -c` clean); before-chains correct.
- ⚠️ Repo lacks request-spec factories/auth helpers; behavior evidenced by the local_dev PoC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)