### PR TITLE
Downgrade reset_token_invalid Sentry capture to warning level

### DIFF
--- a/app/controllers/api/v1/devise/passwords_controller.rb
+++ b/app/controllers/api/v1/devise/passwords_controller.rb
@@ -34,7 +34,7 @@ module Api::V1::Devise
                         :reset_password_sent_at.gte => Devise.reset_password_within.ago).first
 
       if user.nil?
-        Sentry.capture_message("reset_token_invalid - original_token: #{original_token} / reset_password_token: #{reset_password_token} / reset_password_sent_at.gte: #{Devise.reset_password_within.ago}")
+        Sentry.capture_message("reset_token_invalid - original_token: #{original_token} / reset_password_token: #{reset_password_token} / reset_password_sent_at.gte: #{Devise.reset_password_within.ago}", level: :warning)
         render_jsonapi_error(I18n.t('auth.error.password_token_invalid'), 'reset_token_invalid', 400) and return
       else
         user.app_context = current_app


### PR DESCRIPTION
## Summary
- [Sentry issue IDENTITY-MANAGEMENT-BACKEND-A2](https://sentry.samedis.care/organizations/samedis/issues/5922/) ("reset_token_invalid") fires every time someone submits an expired/already-used password reset token — that's expected user behavior (stale email link, reused browser tab, double-submit), not a code defect.
- Event history shows the same `original_token` retried by the same IP weeks apart (once over a full month), plus duplicate submits seconds apart — normal noise from stale links and double-clicks, not a system bug.
- Since `Sentry.capture_message` had no `level:` override, it defaulted to `error`, making this look like an application error and generating alert noise.
- This PR sets `level: :warning` on that capture call so it's still visible in Sentry but no longer treated as an error-tier incident.

## Test plan
- [ ] Trigger `PUT /api/v1/:app/users/password` with a stale/invalid `reset_password_token` and confirm the API still responds with the existing `reset_token_invalid` 400 error (unchanged behavior).
- [ ] Confirm the resulting Sentry event is captured at `warning` level instead of `error`.