### PR TITLE
security: scope user/tenants to caller's own tenants

### DIFF
--- a/app/controllers/api/v1/json_api_controller.rb
+++ b/app/controllers/api/v1/json_api_controller.rb
@@ -435,7 +435,7 @@ class Api::V1::JsonApiController < ApplicationController
   # checks the cando requirements against all tenants the user is a member of
   # @return {Array} of tenants
   def authorized_tenants
-    @authorized_tenants ||= (cando_any_for_tenants?(current_cando_requirements) rescue [])
+    @authorized_tenants ||= (tenants_with_cando(current_cando_requirements) rescue [])
   end
 
   # checks the cando requirements against all tenants the user is a member of
@@ -444,10 +444,25 @@ class Api::V1::JsonApiController < ApplicationController
     @authorized_tenant_ids ||= authorized_tenants.pluck(:id)
   end
 
-  def cando_any_for_tenants?(of_these)
+  # Tenants of the current_user's memberships whose candos satisfy the
+  # requirement. `of_these` uses the nested cando_any? requirement shape
+  # (see get_candos / current_cando_requirements).
+  # @return {Array} of tenant hashes
+  def tenants_with_cando(of_these)
     current_user.tenants.select do |tenant|
       cando_any?(of_these, tenant)
     end
+  end
+
+  # Predicate: does the current_user hold the given cando in ANY of their
+  # tenants? Accepts a single cando string (or a flat AND-combo array) and wraps
+  # it into the cando_any? requirement shape.
+  # NOTE: returns a Boolean on purpose. The previous version returned an Array
+  # (every Array, incl. [], is truthy in Ruby), which — used in a boolean
+  # context — leaked every tenant on the platform (see
+  # User::TenantsController#model_index; pen-test cross-tenant enumeration).
+  def cando_any_for_tenants?(cando)
+    tenants_with_cando([[Array(cando)]]).any?
   end
 
   # Helper to compare required candos with those the current_user has

--- a/app/controllers/api/v1/user/tenants_controller.rb
+++ b/app/controllers/api/v1/user/tenants_controller.rb
@@ -15,16 +15,17 @@ class Api::V1::User::TenantsController < Api::V1::JsonApiController
   }
 
   private
-  # restrict to the current_user's tenant(s).
+  # restrict to the current_user's tenant(s): only a genuine app-wide admin
+  # (holding app-tenant.admin in one of their tenants) may see all tenants;
+  # everyone else is scoped to their own memberships.
+  #
   # SECURITY (pen-test 2026-07, cross-tenant enumeration): the previous guard
-  #   `if cando_any_for_tenants?("#{current_app}/app-tenant.admin")`
-  # was always truthy — cando_any_for_tenants? returns an Array (every Array,
-  # incl. []), and the cando was passed as a String (cando_any? returns false
-  # for non-Array input), so it unconditionally returned every tenant on the
-  # platform. Only genuine app-wide admins (holding app-tenant.admin for this
-  # app) may see all tenants; everyone else is scoped to their own memberships.
+  # relied on cando_any_for_tenants? in a boolean context while that method
+  # returned an Array (always truthy) and was passed a String — so it returned
+  # every tenant on the platform to any authenticated user. cando_any_for_tenants?
+  # is now a real predicate (see JsonApiController).
   def model_index
-    if current_user.global_candos.include?("#{current_app}/app-tenant.admin")
+    if cando_any_for_tenants?("#{current_app}/app-tenant.admin")
       self.class::MODEL_OVERVIEW
     else
       self.class::MODEL_OVERVIEW.where(:id.in => current_user.actor.actor_ids)

--- a/app/controllers/api/v1/user/tenants_controller.rb
+++ b/app/controllers/api/v1/user/tenants_controller.rb
@@ -15,9 +15,16 @@ class Api::V1::User::TenantsController < Api::V1::JsonApiController
   }
 
   private
-  # restrict to the current_user's tenant(s)
+  # restrict to the current_user's tenant(s).
+  # SECURITY (pen-test 2026-07, cross-tenant enumeration): the previous guard
+  #   `if cando_any_for_tenants?("#{current_app}/app-tenant.admin")`
+  # was always truthy — cando_any_for_tenants? returns an Array (every Array,
+  # incl. []), and the cando was passed as a String (cando_any? returns false
+  # for non-Array input), so it unconditionally returned every tenant on the
+  # platform. Only genuine app-wide admins (holding app-tenant.admin for this
+  # app) may see all tenants; everyone else is scoped to their own memberships.
   def model_index
-    if cando_any_for_tenants?("#{current_app}/app-tenant.admin")
+    if current_user.global_candos.include?("#{current_app}/app-tenant.admin")
       self.class::MODEL_OVERVIEW
     else
       self.class::MODEL_OVERVIEW.where(:id.in => current_user.actor.actor_ids)

--- a/spec/controllers/api/v1/user/tenants_controller_spec.rb
+++ b/spec/controllers/api/v1/user/tenants_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+# Regression guard for the cross-tenant enumeration fix (pen-test Issue 1).
+#
+# GET /api/v1/user/tenant (and show/update/destroy, which resolve through
+# #model_index) must return only the caller's own tenants unless the caller
+# actually holds the app-wide `app-tenant.admin` cando. The previous guard
+# `if cando_any_for_tenants?("...app-tenant.admin")` was always truthy
+# (an Array is truthy; the cando was passed as a String), so every user got
+# every tenant on the platform.
+RSpec.describe Api::V1::User::TenantsController do
+  subject(:controller_instance) { described_class.new }
+
+  let(:own_tenant_ids) { [BSON::ObjectId.new, BSON::ObjectId.new] }
+  let(:actor) { double('Actors::User', actor_ids: own_tenant_ids) }
+  let(:user)  { double('User', actor: actor) }
+
+  # The test env has no Devise secret configured, so the first lazy route load
+  # (devise_for :users) would raise. Set one so the controller can be exercised.
+  before { Devise.secret_key ||= 'test-suite-secret' }
+
+  # Mongoid criteria are built in memory (no DB). A tenant-scoped result carries
+  # an `_id` selector (from `where(:id.in => actor_ids)`); the all-tenants result
+  # does not.
+  def index_selector(global_candos)
+    allow(user).to receive(:global_candos).and_return(global_candos)
+    without_partial_double_verification do
+      allow(controller_instance).to receive(:current_user).and_return(user)
+      allow(controller_instance).to receive(:current_app).and_return('samedis-care')
+    end
+    controller_instance.send(:model_index).selector
+  end
+
+  it 'scopes a user without the app-tenant.admin cando to their own tenants' do
+    expect(index_selector([])).to have_key('_id')
+  end
+
+  it 'scopes a user holding only an unrelated cando to their own tenants' do
+    expect(index_selector(['samedis-care/tenant.admin'])).to have_key('_id')
+  end
+
+  it 'does not scope by tenant id for an app-tenant.admin (sees all tenants)' do
+    expect(index_selector(['samedis-care/app-tenant.admin'])).not_to have_key('_id')
+  end
+
+  it 'restricts the own-tenant scope to exactly the caller actor_ids' do
+    expect(index_selector([])['_id']).to eq('$in' => own_tenant_ids)
+  end
+end

--- a/spec/controllers/api/v1/user/tenants_controller_spec.rb
+++ b/spec/controllers/api/v1/user/tenants_controller_spec.rb
@@ -4,10 +4,12 @@ require 'rails_helper'
 #
 # GET /api/v1/user/tenant (and show/update/destroy, which resolve through
 # #model_index) must return only the caller's own tenants unless the caller
-# actually holds the app-wide `app-tenant.admin` cando. The previous guard
-# `if cando_any_for_tenants?("...app-tenant.admin")` was always truthy
-# (an Array is truthy; the cando was passed as a String), so every user got
-# every tenant on the platform.
+# actually holds the app-wide `app-tenant.admin` cando in one of their tenants.
+# The previous guard relied on cando_any_for_tenants? in a boolean context
+# while it returned an Array (always truthy), so every user got every tenant.
+#
+# This drives the real predicate (JsonApiController#cando_any_for_tenants? ->
+# #tenants_with_cando -> #cando_any?) against stubbed tenant memberships.
 RSpec.describe Api::V1::User::TenantsController do
   subject(:controller_instance) { described_class.new }
 
@@ -19,11 +21,13 @@ RSpec.describe Api::V1::User::TenantsController do
   # (devise_for :users) would raise. Set one so the controller can be exercised.
   before { Devise.secret_key ||= 'test-suite-secret' }
 
-  # Mongoid criteria are built in memory (no DB). A tenant-scoped result carries
-  # an `_id` selector (from `where(:id.in => actor_ids)`); the all-tenants result
+  # tenant_candos_per_membership: one candos-array per tenant the user belongs to.
+  # Mongoid criteria are built in memory (no DB); a tenant-scoped result carries
+  # an `_id` selector (from where(:id.in => actor_ids)), the all-tenants result
   # does not.
-  def index_selector(global_candos)
-    allow(user).to receive(:global_candos).and_return(global_candos)
+  def index_selector(tenant_candos_per_membership)
+    tenants = tenant_candos_per_membership.map { |candos| { candos: candos } }
+    allow(user).to receive(:tenants).and_return(tenants)
     without_partial_double_verification do
       allow(controller_instance).to receive(:current_user).and_return(user)
       allow(controller_instance).to receive(:current_app).and_return('samedis-care')
@@ -31,19 +35,19 @@ RSpec.describe Api::V1::User::TenantsController do
     controller_instance.send(:model_index).selector
   end
 
-  it 'scopes a user without the app-tenant.admin cando to their own tenants' do
+  it 'scopes a user with no tenants to their own memberships' do
     expect(index_selector([])).to have_key('_id')
   end
 
-  it 'scopes a user holding only an unrelated cando to their own tenants' do
-    expect(index_selector(['samedis-care/tenant.admin'])).to have_key('_id')
+  it 'scopes a user holding only a per-tenant cando (tenant.admin) to their own tenants' do
+    expect(index_selector([['samedis-care/tenant.admin']])).to have_key('_id')
   end
 
   it 'does not scope by tenant id for an app-tenant.admin (sees all tenants)' do
-    expect(index_selector(['samedis-care/app-tenant.admin'])).not_to have_key('_id')
+    expect(index_selector([['samedis-care/app-tenant.admin']])).not_to have_key('_id')
   end
 
   it 'restricts the own-tenant scope to exactly the caller actor_ids' do
-    expect(index_selector([])['_id']).to eq('$in' => own_tenant_ids)
+    expect(index_selector([['samedis-care/tenant.admin']])['_id']).to eq('$in' => own_tenant_ids)
   end
 end


### PR DESCRIPTION
Fixes the entry point of the reported Broken Access Control → cross-tenant finding.

## Issue
`GET /api/v1/user/tenant` returned all tenants to any authenticated user (and `show/update/destroy` resolved any tenant by id), instead of only the caller's own tenants.

## Root cause
`User::TenantsController#model_index`'s "restrict to the current_user's tenant(s)" guard relied on `cando_any_for_tenants?` in a boolean context — but that method **returned an Array** (and every Array, including `[]`, is truthy in Ruby), and the cando was passed as a String (which `cando_any?` rejects). Either way the guard always took the all-tenants branch and returned `MODEL_OVERVIEW`. `model_show/update/destroy` resolve through `model_index`, so the controller was unscoped for read and write.

## Fix (one PR, 3 commits)
1. **`user/tenants`**: only a caller actually holding the app-wide `app-tenant.admin` cando sees all tenants; everyone else is scoped to their own memberships (`current_user.actor.actor_ids`).
2. **Regression spec** driving the real predicate against stubbed memberships (fails on the pre-fix always-all behaviour).
3. **Root-cause hardening**: `cando_any_for_tenants?` is now a real Boolean predicate (the array-returning finder is split out as `tenants_with_cando`, used by `authorized_tenants` — behaviour unchanged). This removes the `?`-method-returns-a-truthy-Array footgun so no future caller can trip on it.

## Notes
- The remaining steps of the reported chain (cross-tenant user list/modify via `apps/tenants/users`) were already remediated by #264.
- `12 examples, 0 failures` (this spec + the #264 tenant-scope guard spec — no regression on the `tenant_authorize` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
