### PR TITLE
security: pin social id_token signature algorithm (reject alg:none)

### DIFF
--- a/app/services/social_token_verifier.rb
+++ b/app/services/social_token_verifier.rb
@@ -17,11 +17,16 @@ class SocialTokenVerifier
     'google' => {
       jwks_uri: 'https://www.googleapis.com/oauth2/v3/certs',
       issuers: %w[accounts.google.com https://accounts.google.com],
+      # Pin the signature algorithm(s) per provider. The allowed algorithm MUST
+      # come from here, never from the attacker-controlled token header —
+      # otherwise `alg: none` (and RS/HS key confusion) forge arbitrary tokens.
+      algorithms: %w[RS256],
       audiences: -> { google_client_ids }
     },
     'apple' => {
       jwks_uri: 'https://appleid.apple.com/auth/keys',
       issuers: %w[https://appleid.apple.com],
+      algorithms: %w[ES256],
       audiences: -> { apple_client_ids }
     },
     'microsoft' => {
@@ -30,6 +35,7 @@ class SocialTokenVerifier
       # Multi-tenant apps receive tenant-specific issuers (e.g. /{tenant-uuid}/v2.0)
       # even when the app is configured with tenantId "common"
       issuer_pattern: %r{\Ahttps://login\.microsoftonline\.com/[0-9a-f\-]{36}/v2\.0\z},
+      algorithms: %w[RS256],
       audiences: -> { microsoft_client_ids }
     }
   }.freeze
@@ -65,7 +71,10 @@ class SocialTokenVerifier
     raise VerificationError, "No matching key found for kid: #{kid}" unless key_data
 
     jwk = JWT::JWK.import(key_data)
-    algorithms = [header['alg'] || 'RS256']
+    # Never trust the algorithm from the (unverified) token header — pin it to
+    # the provider's expected algorithm(s). This rejects `alg: none` and
+    # RS256/HS256 key-confusion forgeries.
+    algorithms = @config[:algorithms]
 
     decoded = JWT.decode(
       @id_token,

--- a/spec/services/social_token_verifier_spec.rb
+++ b/spec/services/social_token_verifier_spec.rb
@@ -111,10 +111,32 @@ RSpec.describe SocialTokenVerifier do
       verifier = described_class.new(provider:, id_token: token)
       expect { verifier.verify! }.to raise_error(SocialTokenVerifier::VerificationError, /No matching key/)
     end
+
+    # Regression: pen-test 2026-07, CVSS 9.8 — the verifier must pin the signature
+    # algorithm per provider and never trust the token header's `alg`. A forged
+    # unsigned token (alg: none) with an arbitrary email must be rejected.
+    it 'rejects an unsigned token (alg: none)' do
+      token = build_token(valid_claims, key: nil, algorithm: 'none')
+      verifier = described_class.new(provider:, id_token: token)
+      expect { verifier.verify! }.to raise_error(SocialTokenVerifier::VerificationError)
+    end
+
+    it 'rejects an HS256 token (algorithm confusion)' do
+      token = build_token(valid_claims, key: 'attacker-controlled-secret', algorithm: 'HS256')
+      verifier = described_class.new(provider:, id_token: token)
+      expect { verifier.verify! }.to raise_error(SocialTokenVerifier::VerificationError)
+    end
   end
 
   describe 'Apple verification' do
     let(:provider) { 'apple' }
+
+    # Apple signs id_tokens with ES256 (not RS256), so this provider needs an
+    # EC key + EC JWKS.
+    let(:ec_key) { OpenSSL::PKey::EC.generate('prime256v1') }
+    let(:jwks_response) do
+      { 'keys' => [JWT::JWK.new(ec_key, kid:).export] }.to_json
+    end
 
     let(:valid_claims) do
       {
@@ -136,7 +158,7 @@ RSpec.describe SocialTokenVerifier do
     end
 
     it 'verifies a valid Apple id_token' do
-      token = build_token(valid_claims)
+      token = build_token(valid_claims, key: ec_key, algorithm: 'ES256')
       verifier = described_class.new(provider:, id_token: token)
       claims = verifier.verify!
 
@@ -145,7 +167,7 @@ RSpec.describe SocialTokenVerifier do
     end
 
     it 'accepts email_verified as string "true"' do
-      token = build_token(valid_claims)
+      token = build_token(valid_claims, key: ec_key, algorithm: 'ES256')
       verifier = described_class.new(provider:, id_token: token)
       expect { verifier.verify! }.not_to raise_error
     end


### PR DESCRIPTION
Fixes a critical authentication bypass in the native social-login token verification.

## Issue
`SocialTokenVerifier` selected the JWT verification algorithm from the **token header** (`algorithms = [header['alg'] || 'RS256']`). Because the attacker controls the header, setting `alg: none` put `none` into the allowed-algorithm list, so an **unsigned** id_token was accepted. A forged token carrying an arbitrary `email` was then exchanged for a Doorkeeper access token — account takeover with only a victim's email address, no signing key required.

## Fix
Pin the allowed signature algorithm(s) **per provider** in `PROVIDERS` (google/microsoft `RS256`, apple `ES256`) and verify against that list — never the header. This rejects `alg: none` and RS256/HS256 key-confusion forgeries while accepting genuine provider tokens unchanged.

## Tests
- New regression specs: `alg: none` and `HS256` tokens are rejected.
- Existing positive specs still pass; the Apple specs now use an EC key / `ES256` (Apple's real signing algorithm). `18 examples, 0 failures`.

## Note
Signature verification is now enforced. A separate hardening item remains: social login still matches an account by the token's `email` rather than an explicitly-linked provider identity — tracked apart from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
