### PR TITLE
Map users into standard_user when accepting a tenant invite

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -96,7 +96,10 @@ class Invite < ApplicationDocument
 
     action = "_process_accept_#{self.invitable_type}".to_sym
     raise "NO ACCEPT ACTION FOUND: #{action}" unless self.respond_to?(action)
-    self.send(action, *args)
+    # only burn the invite once processing actually granted something, otherwise
+    # it stays retryable on the next login instead of being accepted for nothing
+    return false unless self.send(action, *args)
+
     self.update_attributes(accepted_at: Time.now, done: true)
   end
 
@@ -117,7 +120,20 @@ class Invite < ApplicationDocument
                            .groups
                            .where(system: true, name: :standard_user).first
 
-    standard_group.map_into!(user.actor) unless standard_group.is_a?(Actor)
+    # A tenant without the system group `standard_user` is misconfigured - the group
+    # comes from config/apps/samedis-care/actor_defaults/samedis-care.yml. Do not raise
+    # here: this runs inside the login flow (User#check_acceptances) where an exception
+    # would lock the user out of logging in entirely. Report it and leave the invite
+    # unaccepted so the next login retries once the tenant is repaired.
+    unless standard_group.is_a?(Actor)
+      Sentry.capture_message(
+        "Invite#accept!: no system group 'standard_user' below tenant #{tenant_id} - user not joined",
+        level: :error
+      )
+      return false
+    end
+
+    standard_group.map_into!(user.actor)
 
     true
   end

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -168,6 +168,14 @@ class Invite < ApplicationDocument
   # OU at all. So a missing group is only a misconfiguration where the tenant's own app
   # defaults ask for it.
   def standard_user_expected?(tenant)
+    # Actors::Tenant#profiles_ou_defaults returns nil both when the app declares no
+    # tenant_profiles OU and when the tenant has no organization node at all
+    # (tenant.rb:100, and #organization filters by `available`, so a soft-deleted org tree
+    # gives nil on a live tenant). Only the first is an answer about the app; treating the
+    # second as "not expected" would burn the invite and report nothing, which is the
+    # silent no-op this whole change exists to remove.
+    return true if tenant.organization.nil?
+
     defaults = tenant.profiles_ou_defaults
     return false unless defaults.is_a?(Hash)
 

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -130,13 +130,20 @@ class Invite < ApplicationDocument
     # would lock the user out of logging in entirely. Report it and leave the invite
     # unaccepted so the next login retries once the tenant is repaired.
     unless standard_group.is_a?(Actor)
-      Sentry.capture_message(
-        "Invite#accept!: no system group 'standard_user' below tenant - user not joined",
-        level: :error,
-        tags: { tenant_id: tenant_id.to_s },
-        extra: { invite_id: id.to_s }
-      )
-      return false
+      if standard_user_expected?(tenant)
+        Sentry.capture_message(
+          "Invite#accept!: no system group 'standard_user' below tenant - user not joined",
+          level: :error,
+          tags: { tenant_id: tenant_id.to_s },
+          extra: { invite_id: id.to_s }
+        )
+        return false
+      end
+
+      # This app's tenants do not have that group, so there is nothing for this invite to
+      # grant and nothing to report. Count it as processed - leaving it unaccepted would
+      # re-run it on every login until it expires, for a condition that will never change.
+      return true
     end
 
     # same reasoning: `map_into!` raises on a missing or unpersisted actor (User#actor is
@@ -152,6 +159,22 @@ class Invite < ApplicationDocument
       return false
     end
 
+    true
+  end
+
+  # `standard_user` is a samedis-care actor default. invitable_type 'tenant' is settable for
+  # any app's tenant (both invitation controllers permit it), and other apps declare other
+  # groups - identity-management seeds `identity_management_admins` and no tenant_profiles
+  # OU at all. So a missing group is only a misconfiguration where the tenant's own app
+  # defaults ask for it.
+  def standard_user_expected?(tenant)
+    defaults = tenant.profiles_ou_defaults
+    return false unless defaults.is_a?(Hash)
+
+    Array(defaults['children']).any? { |child| child['name'].to_s.eql?('standard_user') }
+  rescue StandardError
+    # defaults unreadable: assume it was expected, so a real samedis-care misconfiguration
+    # still gets reported instead of being swallowed
     true
   end
 

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -116,8 +116,12 @@ class Invite < ApplicationDocument
     user = get_user
     raise 'NO SUCH USER' unless user.is_a?(User)
 
+    # `available` matters: soft-deleting an ancestor cascades via a raw $set
+    # (`Actor#before_save`), which neither trips the system protection guard nor renames
+    # the group, so a group in a deleted subtree still matches name and system
     standard_group = tenant.descendants
                            .groups
+                           .available
                            .where(system: true, name: :standard_user).first
 
     # A tenant without the system group `standard_user` is misconfigured - the group
@@ -127,13 +131,26 @@ class Invite < ApplicationDocument
     # unaccepted so the next login retries once the tenant is repaired.
     unless standard_group.is_a?(Actor)
       Sentry.capture_message(
-        "Invite#accept!: no system group 'standard_user' below tenant #{tenant_id} - user not joined",
-        level: :error
+        "Invite#accept!: no system group 'standard_user' below tenant - user not joined",
+        level: :error,
+        tags: { tenant_id: tenant_id.to_s },
+        extra: { invite_id: id.to_s }
       )
       return false
     end
 
-    standard_group.map_into!(user.actor)
+    # same reasoning: `map_into!` raises on a missing or unpersisted actor (User#actor is
+    # optional) and can raise out of its own save!, and none of that may reach the login
+    begin
+      standard_group.map_into!(user.actor)
+    rescue StandardError => e
+      Sentry.capture_exception(
+        e,
+        tags: { tenant_id: tenant_id.to_s },
+        extra: { invite_id: id.to_s, group_id: standard_group.id.to_s }
+      )
+      return false
+    end
 
     true
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -98,7 +98,11 @@ if ENV['INDEXES'].present?
   Mongoid::Migrator.migrations_path = ['db/migrate/indexes']
 end
 if ENV['MANUAL'].present?
-  Mongoid::Migrator.migrations_path << 'db/migrate/manual'
+  # sibling of db/migrate, not a subdirectory: Mongoid::Migrator globs each path
+  # recursively (`Dir["#{path}/**/[0-9]*_*.rb"]`), so a subdirectory would already be
+  # picked up by 'db/migrate' above - running manual migrations on every deploy and
+  # raising DuplicateMigrationVersionError once this path is appended as well
+  Mongoid::Migrator.migrations_path << 'db/migrate_manual'
 end
 puts '=' * 80
 puts "Mongoid::Migrator.migrations_path: #{Mongoid::Migrator.migrations_path}"

--- a/db/migrate/manual/20260803081500_repair_missing_standard_user_mappings.rb
+++ b/db/migrate/manual/20260803081500_repair_missing_standard_user_mappings.rb
@@ -1,0 +1,167 @@
+# Repairs users who accepted a `tenant` invite while Invite#_process_accept_tenant had
+# the inverted guard (introduced 2025-04-16 by 635b04f, fixed in #271). Those invites were
+# marked `done: true` without ever mapping the user into the tenant's standard_user group,
+# so `Staff#login_allowed` linked the account while the user got no access and no
+# samedis-care-employee role. See Samedis-care/samedis-care-issues#2403
+#
+# Lives in db/migrate/manual, so it only runs when MANUAL is set:
+#
+#   # 1. report only, writes nothing, is NOT recorded as migrated (default)
+#   MANUAL=true RAILS_ENV=live bundle exec rails db:migrate
+#
+#   # 2. apply, after reviewing the report
+#   MANUAL=true APPLY=true RAILS_ENV=live bundle exec rails db:migrate
+#
+# Knobs: APPLY=true (write), LIMIT=n (cap repairs), TENANT_ID=<id> (single tenant).
+# Run once per cluster - the APAC cluster (RAILS_ENV=apac) has its own data.
+#
+# READ THIS BEFORE APPLYING
+# ------------------------
+# Actor#unmap_from! HARD-deletes the mapping (actor.rb:809), and Actor#before_save deletes
+# any mapping flagged deleted (actor.rb:341). So a membership that somebody revoked on
+# purpose leaves no trace and looks exactly like one this bug never created. This migration
+# therefore CANNOT tell "broken by the bug" from "deliberately removed", and re-granting
+# revoked access is the failure mode to worry about.
+#
+# Two guards narrow that risk, neither eliminates it:
+#   * users who still hold any other live mapping below the tenant are skipped - they have
+#     access already, and their missing standard_user mapping may well be intentional
+#   * the report buckets by acceptance month, so the 2025-04 cliff is visible; anything
+#     accepted before 2025-04 is almost certainly not this bug and worth inspecting
+#
+# The authoritative cross-check lives in the other database: samedis-care `Staff` records
+# with `login_allowed: true` and no `left` date are the users who are supposed to have
+# access. Reconcile the report against that list before running with APPLY=true.
+class RepairMissingStandardUserMappings < Mongoid::Migration
+
+  BUG_INTRODUCED = Time.utc(2025, 4, 16)
+
+  def self.up
+    apply = ENV['APPLY'].present?
+    limit = ENV['LIMIT'].presence&.to_i
+    only_tenant = ENV['TENANT_ID'].presence
+
+    scope = Invite.where(invitable_type: 'tenant', done: true)
+    scope = scope.where(tenant_id: only_tenant) if only_tenant
+
+    stats = Hash.new(0)
+    months = Hash.new(0)
+    repaired = []
+
+    say "scanning #{scope.count} accepted tenant invites (apply=#{apply})"
+
+    scope.each do |invite|
+      stats[:scanned] += 1
+      say "  ... #{stats[:scanned]} scanned" if (stats[:scanned] % 500).zero?
+
+      tenant = tenant_for(invite)
+      if tenant.nil?
+        stats[:skip_tenant_gone] += 1
+        next
+      end
+
+      group = tenant.descendants.groups.available
+                    .where(system: true, name: :standard_user).first
+      if group.nil?
+        # nothing to map into - the tenant itself needs repairing first
+        stats[:skip_tenant_without_group] += 1
+        next
+      end
+
+      user = invite.get_user
+      if !user.is_a?(User) || user.deleted?
+        stats[:skip_user_gone] += 1
+        next
+      end
+
+      actor = user.actor
+      if actor.nil? || actor.new_record?
+        stats[:skip_user_without_actor] += 1
+        next
+      end
+
+      if Actors::Mapping.where(parent: group, map_actor: actor).exists?
+        stats[:already_mapped] += 1
+        next
+      end
+
+      # guard: leave users alone who reach the tenant through some other group
+      if Actors::Mapping.available
+                        .where(map_actor_id: actor.id, :parent_ids.in => [tenant.id]).exists?
+        stats[:skip_has_other_access] += 1
+        next
+      end
+
+      bucket = invite.accepted_at&.strftime('%Y-%m') || 'unknown'
+      months[bucket] += 1
+      stats[:affected] += 1
+      stats[:affected_before_bug] += 1 if invite.accepted_at && invite.accepted_at < BUG_INTRODUCED
+
+      if limit && repaired.size >= limit
+        stats[:over_limit] += 1
+        next
+      end
+
+      unless apply
+        repaired << invite.id
+        next
+      end
+
+      begin
+        group.map_into!(actor)
+        repaired << invite.id
+        stats[:repaired] += 1
+      rescue StandardError => e
+        stats[:failed] += 1
+        say "  FAILED invite=#{invite.id} tenant=#{tenant.id} user=#{user.email}: " \
+            "#{e.class}: #{e.message}"
+      end
+    end
+
+    report(stats, months, apply)
+
+    # keep the migration unrecorded so the real run still has something to do
+    unless apply
+      raise 'DRY RUN: nothing written and migration deliberately not recorded. ' \
+            'Re-run with APPLY=true once the report has been reconciled against the ' \
+            'samedis-care Staff#login_allowed list.'
+    end
+  end
+
+  # Reversing would delete mappings, and because revoked mappings are hard-deleted there
+  # is no way to tell the ones this migration created from ones that already existed or
+  # were legitimately added afterwards. Removing the wrong one silently drops a user's
+  # access, so this is not reversible.
+  def self.down
+    raise Mongoid::IrreversibleMigration,
+          'Cannot safely remove standard_user mappings - see the comment in this file. ' \
+          'To revoke a single user use group.unmap_from!(user.actor) explicitly.'
+  end
+
+  def self.tenant_for(invite)
+    return nil if invite.tenant_id.blank?
+
+    oid = BSON::ObjectId.from_string(invite.tenant_id.to_s) rescue nil
+    return nil if oid.nil?
+
+    Actors::Tenant.available.where(_id: oid).first
+  end
+
+  def self.report(stats, months, apply)
+    say '=' * 76
+    say "accepted tenant invites with no standard_user mapping, by acceptance month"
+    say "(the inverted guard shipped with 635b04f on #{BUG_INTRODUCED.strftime('%Y-%m-%d')})"
+    months.keys.sort.each do |month|
+      say format('  %-8s %5d %s', month, months[month], '#' * [months[month], 50].min)
+    end
+    say '-' * 76
+    %i[scanned affected affected_before_bug repaired failed already_mapped
+       skip_has_other_access skip_tenant_without_group skip_tenant_gone
+       skip_user_gone skip_user_without_actor over_limit].each do |key|
+      say format('  %-26s %6d', key, stats[key])
+    end
+    say '=' * 76
+    say(apply ? "repaired #{stats[:repaired]} mapping(s)" : 'DRY RUN - nothing written')
+  end
+
+end

--- a/db/migrate_manual/20260803081500_repair_missing_standard_user_mappings.rb
+++ b/db/migrate_manual/20260803081500_repair_missing_standard_user_mappings.rb
@@ -12,7 +12,8 @@
 #   # 2. apply, after reviewing the report
 #   MANUAL=true APPLY=true RAILS_ENV=live bundle exec rails db:migrate
 #
-# Knobs: APPLY=true (write), LIMIT=n (cap repairs), TENANT_ID=<id> (single tenant).
+# Knobs: APPLY=true (write), LIMIT=n (cap repairs), TENANT_ID=<id> (single tenant),
+#        SINCE=YYYY-MM-DD or SINCE=all (default floor: 2025-04-16, the day the bug shipped).
 # Run once per cluster - the APAC cluster (RAILS_ENV=apac) has its own data.
 #
 # READ THIS BEFORE APPLYING
@@ -36,10 +37,23 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
 
   BUG_INTRODUCED = Time.utc(2025, 4, 16)
 
+  # Anything accepted before BUG_INTRODUCED has some other cause and is not repaired:
+  # the first live report found 68 of 94 predating the bug, going back to 2019, so this
+  # state is long-standing and not a fingerprint of the inverted guard. SINCE=all lifts
+  # the floor, SINCE=2024-01-01 moves it.
+  def self.since_floor
+    raw = ENV['SINCE'].to_s.strip
+    return nil if raw.casecmp('all').zero?
+    return BUG_INTRODUCED if raw.empty?
+
+    Time.parse(raw).utc
+  end
+
   def self.up
     apply = ENV['APPLY'].present?
     limit = ENV['LIMIT'].presence&.to_i
     only_tenant = ENV['TENANT_ID'].presence
+    since = since_floor
 
     scope = Invite.where(invitable_type: 'tenant', done: true)
     scope = scope.where(tenant_id: only_tenant) if only_tenant
@@ -97,6 +111,14 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
       stats[:affected] += 1
       stats[:affected_before_bug] += 1 if invite.accepted_at && invite.accepted_at < BUG_INTRODUCED
 
+      # counted as affected for the report, but out of repair scope
+      if since && (invite.accepted_at.nil? || invite.accepted_at < since)
+        stats[:skip_before_since] += 1
+        next
+      end
+
+      stats[:in_repair_scope] += 1
+
       if limit && repaired.size >= limit
         stats[:over_limit] += 1
         next
@@ -118,7 +140,7 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
       end
     end
 
-    report(stats, months, apply)
+    report(stats, months, apply, since)
 
     # keep the migration unrecorded so the real run still has something to do
     unless apply
@@ -147,7 +169,7 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
     Actors::Tenant.available.where(_id: oid).first
   end
 
-  def self.report(stats, months, apply)
+  def self.report(stats, months, apply, since = nil)
     say '=' * 76
     say "accepted tenant invites with no standard_user mapping, by acceptance month"
     say "(the inverted guard shipped with 635b04f on #{BUG_INTRODUCED.strftime('%Y-%m-%d')})"
@@ -155,11 +177,20 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
       say format('  %-8s %5d %s', month, months[month], '#' * [months[month], 50].min)
     end
     say '-' * 76
-    %i[scanned affected affected_before_bug repaired failed already_mapped
-       skip_has_other_access skip_tenant_without_group skip_tenant_gone
-       skip_user_gone skip_user_without_actor over_limit].each do |key|
+    %i[scanned affected affected_before_bug skip_before_since in_repair_scope
+       repaired failed already_mapped skip_has_other_access
+       skip_tenant_without_group skip_tenant_gone skip_user_gone
+       skip_user_without_actor over_limit].each do |key|
       say format('  %-26s %6d', key, stats[key])
     end
+    say '-' * 76
+    say(if since
+          "repair scope: accepted on/after #{since.strftime('%Y-%m-%d')} " \
+            "(#{stats[:in_repair_scope]} of #{stats[:affected]} affected). " \
+            'SINCE=all lifts the floor, SINCE=YYYY-MM-DD moves it.'
+        else
+          "repair scope: NO date floor, all #{stats[:affected]} affected rows in scope"
+        end)
     say '=' * 76
     say(apply ? "repaired #{stats[:repaired]} mapping(s)" : 'DRY RUN - nothing written')
   end

--- a/db/migrate_manual/20260803081500_repair_missing_standard_user_mappings.rb
+++ b/db/migrate_manual/20260803081500_repair_missing_standard_user_mappings.rb
@@ -13,7 +13,8 @@
 #   MANUAL=true APPLY=true RAILS_ENV=live bundle exec rails db:migrate
 #
 # Knobs: APPLY=true (write), LIMIT=n (cap repairs), TENANT_ID=<id> (single tenant),
-#        SINCE=YYYY-MM-DD or SINCE=all (default floor: 2025-04-16, the day the bug shipped).
+#        SINCE=YYYY-MM-DD or SINCE=all (default floor: 2025-04-16, the day the bug shipped),
+#        EMAILS=a@x.de,b@y.de (repair only these, after confirming them on the samedis side).
 # Run once per cluster - the APAC cluster (RAILS_ENV=apac) has its own data.
 #
 # READ THIS BEFORE APPLYING
@@ -54,6 +55,10 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
     limit = ENV['LIMIT'].presence&.to_i
     only_tenant = ENV['TENANT_ID'].presence
     since = since_floor
+    # EMAILS=a@x.de,b@y.de restricts the repair to an explicitly confirmed set. Rows
+    # outside it are still reported, so the full picture stays visible.
+    only_emails = ENV['EMAILS'].to_s.split(/[,\s]+/).map { |e| e.downcase.strip }
+                               .reject(&:empty?).presence
 
     scope = Invite.where(invitable_type: 'tenant', done: true)
     scope = scope.where(tenant_id: only_tenant) if only_tenant
@@ -118,9 +123,15 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
         next
       end
 
+      if only_emails && !only_emails.include?(user.email.to_s.downcase)
+        stats[:skip_not_in_emails] += 1
+        next
+      end
+
       stats[:in_repair_scope] += 1
       in_scope << { email: user.email, tenant: tenant.name.to_s,
-                    accepted_at: invite.accepted_at, invite_id: invite.id.to_s }
+                    tenant_id: tenant.id.to_s, accepted_at: invite.accepted_at,
+                    invite_id: invite.id.to_s }
 
       if limit && repaired.size >= limit
         stats[:over_limit] += 1
@@ -180,8 +191,8 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
       say format('  %-8s %5d %s', month, months[month], '#' * [months[month], 50].min)
     end
     say '-' * 76
-    %i[scanned affected affected_before_bug skip_before_since in_repair_scope
-       repaired failed already_mapped skip_has_other_access
+    %i[scanned affected affected_before_bug skip_before_since skip_not_in_emails
+       in_repair_scope repaired failed already_mapped skip_has_other_access
        skip_tenant_without_group skip_tenant_gone skip_user_gone
        skip_user_without_actor over_limit].each do |key|
       say format('  %-26s %6d', key, stats[key])
@@ -207,6 +218,11 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
       say '-' * 76
       mails = in_scope.map { |r| r[:email].presence }
       say "emails only: #{mails.compact.sort.join(' ')}"
+      # email alone is ambiguous for a customer running many tenants - the same person can
+      # be staff at several, and only one of them may be the one that lost access
+      say 'email|tenant pairs: ' +
+          in_scope.select { |r| r[:email].present? }
+                  .map { |r| "#{r[:email]}|#{r[:tenant_id]}" }.sort.join(' ')
       # without an address these cannot be matched against the samedis-care staff list,
       # so they need deciding by hand rather than slipping through with the rest
       blank = in_scope.reject { |r| r[:email].present? }

--- a/db/migrate_manual/20260803081500_repair_missing_standard_user_mappings.rb
+++ b/db/migrate_manual/20260803081500_repair_missing_standard_user_mappings.rb
@@ -4,7 +4,7 @@
 # so `Staff#login_allowed` linked the account while the user got no access and no
 # samedis-care-employee role. See Samedis-care/samedis-care-issues#2403
 #
-# Lives in db/migrate/manual, so it only runs when MANUAL is set:
+# Lives in db/migrate_manual, so it only runs when MANUAL is set:
 #
 #   # 1. report only, writes nothing, is NOT recorded as migrated (default)
 #   MANUAL=true RAILS_ENV=live bundle exec rails db:migrate

--- a/db/migrate_manual/20260803081500_repair_missing_standard_user_mappings.rb
+++ b/db/migrate_manual/20260803081500_repair_missing_standard_user_mappings.rb
@@ -199,12 +199,22 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
       say "rows in repair scope (#{in_scope.size}) - cross-check these against the " \
           'samedis-care Staff#login_allowed list before applying:'
       in_scope.sort_by { |r| r[:accepted_at] || Time.at(0) }.each do |row|
-        say format('  %-10s %-38s %s',
+        say format('  %-10s %-38s %-26s invite=%s',
                    row[:accepted_at]&.strftime('%Y-%m-%d') || '?',
-                   row[:email].to_s[0, 38], row[:tenant][0, 26])
+                   row[:email].presence || '<NO EMAIL>',
+                   row[:tenant][0, 26], row[:invite_id])
       end
       say '-' * 76
-      say "emails only: #{in_scope.map { |r| r[:email] }.compact.sort.join(' ')}"
+      mails = in_scope.map { |r| r[:email].presence }
+      say "emails only: #{mails.compact.sort.join(' ')}"
+      # without an address these cannot be matched against the samedis-care staff list,
+      # so they need deciding by hand rather than slipping through with the rest
+      blank = in_scope.reject { |r| r[:email].present? }
+      if blank.any?
+        say "WARNING: #{blank.size} of #{in_scope.size} in-scope rows have no email and " \
+            'are NOT covered by the list above - check by invite id: ' \
+            "#{blank.map { |r| r[:invite_id] }.join(' ')}"
+      end
     end
     say '=' * 76
     say(apply ? "repaired #{stats[:repaired]} mapping(s)" : 'DRY RUN - nothing written')

--- a/db/migrate_manual/20260803081500_repair_missing_standard_user_mappings.rb
+++ b/db/migrate_manual/20260803081500_repair_missing_standard_user_mappings.rb
@@ -4,13 +4,24 @@
 # so `Staff#login_allowed` linked the account while the user got no access and no
 # samedis-care-employee role. See Samedis-care/samedis-care-issues#2403
 #
-# Lives in db/migrate_manual, so it only runs when MANUAL is set:
+# Lives in db/migrate_manual, so it is only on the migration path when MANUAL is set.
+#
+# Use db:migrate:up with an explicit VERSION, NOT db:migrate. MANUAL appends to the path
+# rather than replacing it (config/application.rb:95,105), so `db:migrate` would first
+# apply every pending regular migration on that cluster - and the dry-run raise below would
+# then cancel anything ordered after this one. On a cluster that is behind, or on APAC which
+# has never seen this file, that is not a report but a deploy. Check `db:migrate:status`
+# first if unsure.
 #
 #   # 1. report only, writes nothing, is NOT recorded as migrated (default)
-#   MANUAL=true RAILS_ENV=live bundle exec rails db:migrate
+#   MANUAL=true VERSION=20260803081500 RAILS_ENV=live bundle exec rails db:migrate:up
 #
-#   # 2. apply, after reviewing the report
-#   MANUAL=true APPLY=true RAILS_ENV=live bundle exec rails db:migrate
+#   # 2. apply, after reviewing the report and confirming the set on the samedis-care side
+#   MANUAL=true APPLY=true EMAILS=a@x.de,b@y.de VERSION=20260803081500 \
+#     RAILS_ENV=live bundle exec rails db:migrate:up
+#
+# Do not set INDEXES together with MANUAL: the INDEXES branch assigns the path while the
+# MANUAL branch appends, so db/migrate itself drops out.
 #
 # Knobs: APPLY=true (write), LIMIT=n (cap repairs), TENANT_ID=<id> (single tenant),
 #        SINCE=YYYY-MM-DD or SINCE=all (default floor: 2025-04-16, the day the bug shipped),
@@ -47,7 +58,16 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
     return nil if raw.casecmp('all').zero?
     return BUG_INTRODUCED if raw.empty?
 
-    Time.parse(raw).utc
+    # Time.parse is lenient enough to turn a typo into a silent wrong answer: SINCE=2025
+    # parses as a time of day, giving a floor of today and a run that reports
+    # `in_repair_scope 0` as if there were nothing to repair.
+    unless raw.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+      raise "SINCE must be YYYY-MM-DD or 'all', got #{raw.inspect}"
+    end
+
+    # built as UTC rather than via Time.parse, which would anchor the date in the server's
+    # local zone and land an hour off from BUG_INTRODUCED
+    Time.utc(*raw.split('-').map(&:to_i))
   end
 
   def self.up
@@ -67,6 +87,7 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
     months = Hash.new(0)
     repaired = []
     in_scope = []
+    groups_by_tenant = {}
 
     say "scanning #{scope.count} accepted tenant invites (apply=#{apply})"
 
@@ -80,8 +101,11 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
         next
       end
 
-      group = tenant.descendants.groups.available
-                    .where(system: true, name: :standard_user).first
+      # accepted tenant invites cluster heavily by tenant, so memoize rather than
+      # repeating this lookup for every invite of the same tenant
+      groups_by_tenant[tenant.id] ||= tenant.descendants.groups.available
+                                            .where(system: true, name: :standard_user).first
+      group = groups_by_tenant[tenant.id]
       if group.nil?
         # nothing to map into - the tenant itself needs repairing first
         stats[:skip_tenant_without_group] += 1
@@ -129,14 +153,17 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
       end
 
       stats[:in_repair_scope] += 1
-      in_scope << { email: user.email, tenant: tenant.name.to_s,
-                    tenant_id: tenant.id.to_s, accepted_at: invite.accepted_at,
-                    invite_id: invite.id.to_s }
 
       if limit && repaired.size >= limit
         stats[:over_limit] += 1
         next
       end
+
+      # pushed only past the limit check, so the printed list is the audit trail of what
+      # was actually written rather than of what merely passed the filters
+      in_scope << { email: user.email, tenant: tenant.name.to_s,
+                    tenant_id: tenant.id.to_s, accepted_at: invite.accepted_at,
+                    invite_id: invite.id.to_s }
 
       unless apply
         repaired << invite.id

--- a/db/migrate_manual/20260803081500_repair_missing_standard_user_mappings.rb
+++ b/db/migrate_manual/20260803081500_repair_missing_standard_user_mappings.rb
@@ -61,6 +61,7 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
     stats = Hash.new(0)
     months = Hash.new(0)
     repaired = []
+    in_scope = []
 
     say "scanning #{scope.count} accepted tenant invites (apply=#{apply})"
 
@@ -118,6 +119,8 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
       end
 
       stats[:in_repair_scope] += 1
+      in_scope << { email: user.email, tenant: tenant.name.to_s,
+                    accepted_at: invite.accepted_at, invite_id: invite.id.to_s }
 
       if limit && repaired.size >= limit
         stats[:over_limit] += 1
@@ -140,7 +143,7 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
       end
     end
 
-    report(stats, months, apply, since)
+    report(stats, months, apply, since, in_scope)
 
     # keep the migration unrecorded so the real run still has something to do
     unless apply
@@ -169,7 +172,7 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
     Actors::Tenant.available.where(_id: oid).first
   end
 
-  def self.report(stats, months, apply, since = nil)
+  def self.report(stats, months, apply, since = nil, in_scope = [])
     say '=' * 76
     say "accepted tenant invites with no standard_user mapping, by acceptance month"
     say "(the inverted guard shipped with 635b04f on #{BUG_INTRODUCED.strftime('%Y-%m-%d')})"
@@ -191,6 +194,18 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
         else
           "repair scope: NO date floor, all #{stats[:affected]} affected rows in scope"
         end)
+    if in_scope.any?
+      say '-' * 76
+      say "rows in repair scope (#{in_scope.size}) - cross-check these against the " \
+          'samedis-care Staff#login_allowed list before applying:'
+      in_scope.sort_by { |r| r[:accepted_at] || Time.at(0) }.each do |row|
+        say format('  %-10s %-38s %s',
+                   row[:accepted_at]&.strftime('%Y-%m-%d') || '?',
+                   row[:email].to_s[0, 38], row[:tenant][0, 26])
+      end
+      say '-' * 76
+      say "emails only: #{in_scope.map { |r| r[:email] }.compact.sort.join(' ')}"
+    end
     say '=' * 76
     say(apply ? "repaired #{stats[:repaired]} mapping(s)" : 'DRY RUN - nothing written')
   end

--- a/db/migrate_manual/20260803081500_repair_missing_standard_user_mappings.rb
+++ b/db/migrate_manual/20260803081500_repair_missing_standard_user_mappings.rb
@@ -20,6 +20,19 @@
 #   MANUAL=true APPLY=true EMAILS=a@x.de,b@y.de VERSION=20260803081500 \
 #     RAILS_ENV=live bundle exec rails db:migrate:up
 #
+# An APPLY run does not raise, so it records the version - and Mongoid::Migrator#run is a
+# silent no-op once a version is recorded: no output, no report, no error. A second batch
+# via db:migrate:up would look like a clean run that did nothing, and #down raises
+# IrreversibleMigration so there is no way back through the migrator either. This is not
+# hypothetical; it happened on live on 2026-08-03. Either apply the whole confirmed set in
+# one run and treat the recorded version as final, or run later batches directly, which
+# ignores the recorded version and needs no MANUAL because nothing consults the path:
+#
+#   # 3. later batches, and the repeatable way to re-report after recording
+#   APPLY=true EMAILS=c@x.de RAILS_ENV=live bundle exec rails runner \
+#     'load Rails.root.join("db/migrate_manual/20260803081500_repair_missing_standard_user_mappings.rb").to_s
+#      RepairMissingStandardUserMappings.up'
+#
 # Do not set INDEXES together with MANUAL: the INDEXES branch assigns the path while the
 # MANUAL branch appends, so db/migrate itself drops out.
 #
@@ -103,9 +116,12 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
 
       # accepted tenant invites cluster heavily by tenant, so memoize rather than
       # repeating this lookup for every invite of the same tenant
-      groups_by_tenant[tenant.id] ||= tenant.descendants.groups.available
+      # fetch rather than ||=, which would re-query for every invite of a tenant that has
+      # no group - the one population the memoization is meant to cover
+      group = groups_by_tenant.fetch(tenant.id) do
+        groups_by_tenant[tenant.id] = tenant.descendants.groups.available
                                             .where(system: true, name: :standard_user).first
-      group = groups_by_tenant[tenant.id]
+      end
       if group.nil?
         # nothing to map into - the tenant itself needs repairing first
         stats[:skip_tenant_without_group] += 1
@@ -159,20 +175,21 @@ class RepairMissingStandardUserMappings < Mongoid::Migration
         next
       end
 
-      # pushed only past the limit check, so the printed list is the audit trail of what
-      # was actually written rather than of what merely passed the filters
-      in_scope << { email: user.email, tenant: tenant.name.to_s,
-                    tenant_id: tenant.id.to_s, accepted_at: invite.accepted_at,
-                    invite_id: invite.id.to_s }
+      # recorded only where something was actually written (or would be, on a dry run), so
+      # the printed list is a write log rather than a list of rows that passed the filters
+      row = { email: user.email, tenant: tenant.name.to_s, tenant_id: tenant.id.to_s,
+              accepted_at: invite.accepted_at, invite_id: invite.id.to_s }
 
       unless apply
         repaired << invite.id
+        in_scope << row
         next
       end
 
       begin
         group.map_into!(actor)
         repaired << invite.id
+        in_scope << row
         stats[:repaired] += 1
       rescue StandardError => e
         stats[:failed] += 1

--- a/spec/migrations/repair_missing_standard_user_mappings_spec.rb
+++ b/spec/migrations/repair_missing_standard_user_mappings_spec.rb
@@ -1,0 +1,128 @@
+require 'rails_helper'
+require Rails.root.join('db/migrate/manual/20260803081500_repair_missing_standard_user_mappings')
+
+# Cover for the manual repair migration for Samedis-care/samedis-care-issues#2403.
+# Runs scoped to its own tenant via TENANT_ID so leftovers from other specs cannot
+# influence the outcome.
+RSpec.describe RepairMissingStandardUserMappings do
+  let(:sfx) { SecureRandom.hex(4) }
+  let(:email) { "repair-#{sfx}@invite-spec.test" }
+
+  let!(:tenant) { Actors::Tenant.create!(name: "t#{sfx}") }
+  let!(:organization) { Actors::Organization.create!(name: "org#{sfx}", parent: tenant) }
+  let!(:tenant_profiles) { Actors::Ou.create!(name: 'tenant_profiles', parent: organization) }
+  let!(:standard_group) do
+    Actors::Group.create!(name: 'standard_user', parent: tenant_profiles, system: true)
+  end
+
+  let!(:user) do
+    User.new(
+      email: email,
+      email_confirmation: email,
+      first_name: 'Repair',
+      last_name: 'Spec',
+      password: 'Sup3rSecret!123',
+      password_confirmation: 'Sup3rSecret!123'
+    ).tap do |u|
+      u.skip_confirmation!
+      u.save!
+    end
+  end
+  let!(:user_actor) { user.actor }
+
+  # the state the bug left behind: accepted, done, but no mapping
+  let!(:invite) do
+    Invite.create!(
+      email: email,
+      tenant: tenant,
+      invitable_type: 'tenant',
+      invitable_id: tenant.id.to_s,
+      auto_accept: true,
+      valid_until: 1.day.from_now
+    ).tap { |i| i.set(done: true, accepted_at: Time.utc(2025, 6, 1)) }
+  end
+
+  around do |example|
+    was_verbose = Mongoid::Migration.verbose
+    Mongoid::Migration.verbose = false
+    ENV['TENANT_ID'] = tenant.id.to_s
+    example.run
+  ensure
+    Mongoid::Migration.verbose = was_verbose
+    ENV.delete('TENANT_ID')
+    ENV.delete('APPLY')
+    ENV.delete('LIMIT')
+  end
+
+  after do
+    Invite.where(email: email).delete_all
+    Actor.where(:parent_ids.in => [tenant.id]).delete_all
+    user_actor&.delete
+    user.delete
+    tenant.delete
+  end
+
+  def mappings
+    Actors::Mapping.where(parent: standard_group, map_actor: user_actor)
+  end
+
+  describe 'without APPLY' do
+    it 'writes nothing' do
+      expect { described_class.up rescue nil }.not_to change { mappings.count }.from(0)
+    end
+
+    it 'raises so the migration is not recorded as run' do
+      expect { described_class.up }.to raise_error(/DRY RUN/)
+    end
+  end
+
+  describe 'with APPLY' do
+    before { ENV['APPLY'] = 'true' }
+
+    it 'maps the user into standard_user' do
+      expect { described_class.up }.to change { mappings.count }.from(0).to(1)
+    end
+
+    it 'is idempotent' do
+      described_class.up
+      described_class.up
+
+      expect(mappings.count).to eq(1)
+    end
+
+    it 'leaves an already mapped user untouched' do
+      standard_group.map_into!(user_actor)
+
+      expect { described_class.up }.not_to change { mappings.count }.from(1)
+    end
+
+    it 'respects LIMIT' do
+      ENV['LIMIT'] = '0'
+
+      expect { described_class.up }.not_to change { mappings.count }.from(0)
+    end
+
+    # a user who reaches the tenant through another group is not this bug, and their
+    # missing standard_user mapping may well be deliberate
+    it 'skips users who already have other access to the tenant' do
+      other_group = Actors::Group.create!(
+        name: "custom_#{sfx}", parent: tenant_profiles, system: true
+      )
+      other_group.map_into!(user_actor)
+
+      expect { described_class.up }.not_to change { mappings.count }.from(0)
+    end
+
+    it 'ignores invites that were never accepted' do
+      invite.set(done: false, accepted_at: nil)
+
+      expect { described_class.up }.not_to change { mappings.count }.from(0)
+    end
+  end
+
+  describe '.down' do
+    it 'refuses to reverse' do
+      expect { described_class.down }.to raise_error(Mongoid::IrreversibleMigration)
+    end
+  end
+end

--- a/spec/migrations/repair_missing_standard_user_mappings_spec.rb
+++ b/spec/migrations/repair_missing_standard_user_mappings_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-require Rails.root.join('db/migrate/manual/20260803081500_repair_missing_standard_user_mappings')
+require Rails.root.join('db/migrate_manual/20260803081500_repair_missing_standard_user_mappings')
 
 # Cover for the manual repair migration for Samedis-care/samedis-care-issues#2403.
 # Runs scoped to its own tenant via TENANT_ID so leftovers from other specs cannot

--- a/spec/migrations/repair_missing_standard_user_mappings_spec.rb
+++ b/spec/migrations/repair_missing_standard_user_mappings_spec.rb
@@ -160,6 +160,43 @@ RSpec.describe RepairMissingStandardUserMappings do
     end
   end
 
+  describe 'SINCE parsing' do
+    it 'rejects input Time.parse would silently misread' do
+      ENV['SINCE'] = '2025'
+
+      expect { described_class.since_floor }.to raise_error(/SINCE must be YYYY-MM-DD/)
+    end
+
+    it 'rejects nonsense instead of aborting with a bare ArgumentError' do
+      ENV['SINCE'] = 'letztes jahr'
+
+      expect { described_class.since_floor }.to raise_error(/SINCE must be YYYY-MM-DD/)
+    end
+
+    it 'accepts a full date' do
+      ENV['SINCE'] = '2024-01-01'
+
+      expect(described_class.since_floor).to eq(Time.utc(2024, 1, 1))
+    end
+  end
+
+  describe 'LIMIT and the printed audit list' do
+    before do
+      ENV['APPLY'] = 'true'
+      ENV['LIMIT'] = '0'
+    end
+
+    it 'does not list rows it did not repair' do
+      expect(described_class).to receive(:report) do |stats, _months, _apply, _since, in_scope|
+        expect(stats[:in_repair_scope]).to eq(1)
+        expect(stats[:over_limit]).to eq(1)
+        expect(in_scope).to be_empty
+      end
+
+      described_class.up
+    end
+  end
+
   describe '.down' do
     it 'refuses to reverse' do
       expect { described_class.down }.to raise_error(Mongoid::IrreversibleMigration)

--- a/spec/migrations/repair_missing_standard_user_mappings_spec.rb
+++ b/spec/migrations/repair_missing_standard_user_mappings_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe RepairMissingStandardUserMappings do
     ENV.delete('TENANT_ID')
     ENV.delete('APPLY')
     ENV.delete('LIMIT')
+    ENV.delete('SINCE')
   end
 
   after do
@@ -115,6 +116,45 @@ RSpec.describe RepairMissingStandardUserMappings do
 
     it 'ignores invites that were never accepted' do
       invite.set(done: false, accepted_at: nil)
+
+      expect { described_class.up }.not_to change { mappings.count }.from(0)
+    end
+
+    # 68 of the first live report's 94 affected rows predate the bug, going back to 2019,
+    # so the default floor keeps the repair to rows this bug can actually explain
+    context 'with an acceptance date before the bug' do
+      before { invite.set(accepted_at: Time.utc(2024, 10, 1)) }
+
+      it 'does not repair by default' do
+        expect { described_class.up }.not_to change { mappings.count }.from(0)
+      end
+
+      it 'still counts it as affected in the report' do
+        expect(described_class).to receive(:report) do |stats, _months, _apply, since|
+          expect(stats[:affected]).to eq(1)
+          expect(stats[:skip_before_since]).to eq(1)
+          expect(stats[:in_repair_scope]).to eq(0)
+          expect(since).to eq(described_class::BUG_INTRODUCED)
+        end
+
+        described_class.up
+      end
+
+      it 'repairs with SINCE=all' do
+        ENV['SINCE'] = 'all'
+
+        expect { described_class.up }.to change { mappings.count }.from(0).to(1)
+      end
+
+      it 'repairs with an explicit earlier SINCE' do
+        ENV['SINCE'] = '2024-01-01'
+
+        expect { described_class.up }.to change { mappings.count }.from(0).to(1)
+      end
+    end
+
+    it 'does not repair invites with no acceptance date' do
+      invite.set(accepted_at: nil)
 
       expect { described_class.up }.not_to change { mappings.count }.from(0)
     end

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -138,6 +138,24 @@ RSpec.describe Invite, type: :model do
       end
     end
 
+    # invitable_type 'tenant' is settable for any app's tenant, and other apps declare
+    # other groups - identity-management has no tenant_profiles OU at all - so a missing
+    # standard_user group is not a misconfiguration there
+    context 'when the app does not declare a standard_user group' do
+      before { allow(invite).to receive(:standard_user_expected?).and_return(false) }
+
+      it 'accepts the invite instead of retrying it forever' do
+        expect(invite.accept!).to be_truthy
+        expect(invite.reload.done).to be(true)
+      end
+
+      it 'does not report a misconfiguration' do
+        expect(Sentry).not_to receive(:capture_message)
+
+        invite.accept!
+      end
+    end
+
     # the `system: true` filter is deliberate - a customer-created group of the same
     # name must not be able to hand out the samedis-care-employee role
     context 'when standard_user exists but is not a system group' do

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -26,12 +26,15 @@ RSpec.describe Invite, type: :model do
     end
   end
 
+  # held separately so cleanup still works in examples that detach the actor
+  let!(:user_actor) { user.actor }
+
   # delete instead of destroy: skips the actor callbacks (cache expiry, write protection)
   # which are irrelevant here and would only slow the suite down
   after do
     Invite.where(email: email).delete_all
     Actor.where(:parent_ids.in => [tenant.id]).delete_all
-    user.actor&.delete
+    user_actor&.delete
     user.delete
     tenant.delete
   end
@@ -73,6 +76,43 @@ RSpec.describe Invite, type: :model do
         invite.accept!
 
         expect(mappings_into(standard_group).count).to eq(1)
+      end
+
+      it 'reports and stays retryable when the user has no actor to map' do
+        allow(Sentry).to receive(:capture_exception)
+        user.set(actor_id: nil)
+
+        expect { invite.accept! }.not_to raise_error
+        expect(invite.reload.done).to be(false)
+        expect(Sentry).to have_received(:capture_exception)
+      end
+    end
+
+    # soft-deleting an ancestor cascades through Actor#before_save with a raw
+    # `descendants.set(deleted: ...)`, which skips both the system protection guard and
+    # the rename applied to the deleted record itself - so the group keeps its name and
+    # system flag and would otherwise still be found here
+    context 'when the standard_user group sits in a soft-deleted subtree' do
+      let!(:deleted_group) do
+        Actors::Group.create!(name: 'standard_user', parent: tenant_profiles, system: true)
+                     .tap { |g| g.set(deleted: true) }
+      end
+
+      it 'does not map into it and leaves the invite retryable' do
+        allow(Sentry).to receive(:capture_message)
+
+        expect(invite.accept!).to be(false)
+        expect(mappings_into(deleted_group).count).to eq(0)
+        expect(invite.reload.done).to be(false)
+      end
+
+      it 'still maps into a live group next to the deleted one' do
+        live_group = Actors::Group.create!(
+          name: 'standard_user_live', parent: tenant_profiles, system: true
+        )
+        live_group.set(name: 'standard_user')
+
+        expect { invite.accept! }.to change { mappings_into(live_group).count }.from(0).to(1)
       end
     end
 

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -1,0 +1,143 @@
+require 'rails_helper'
+
+# Regression cover for the inverted guard in Invite#_process_accept_tenant that made
+# the Samedis.care "auto join facility" feature (Staff#login_allowed) a silent no-op.
+# See Samedis-care/samedis-care-issues#2403
+RSpec.describe Invite, type: :model do
+  let(:sfx) { SecureRandom.hex(4) }
+  let(:email) { "invite-#{sfx}@invite-spec.test" }
+
+  let!(:tenant) { Actors::Tenant.create!(name: "t#{sfx}") }
+  let!(:organization) { Actors::Organization.create!(name: "org#{sfx}", parent: tenant) }
+  let!(:tenant_profiles) { Actors::Ou.create!(name: 'tenant_profiles', parent: organization) }
+
+  let!(:user) do
+    User.new(
+      email: email,
+      email_confirmation: email,
+      first_name: 'Invite',
+      last_name: 'Spec',
+      password: 'Sup3rSecret!123',
+      password_confirmation: 'Sup3rSecret!123'
+    ).tap do |u|
+      # the confirmation mail needs an app context we do not have here
+      u.skip_confirmation!
+      u.save!
+    end
+  end
+
+  # delete instead of destroy: skips the actor callbacks (cache expiry, write protection)
+  # which are irrelevant here and would only slow the suite down
+  after do
+    Invite.where(email: email).delete_all
+    Actor.where(:parent_ids.in => [tenant.id]).delete_all
+    user.actor&.delete
+    user.delete
+    tenant.delete
+  end
+
+  describe "#accept! with invitable_type 'tenant'" do
+    subject(:invite) do
+      Invite.create!(
+        email: email,
+        tenant: tenant,
+        invitable_type: 'tenant',
+        invitable_id: tenant.id.to_s,
+        auto_accept: true,
+        valid_until: 1.day.from_now
+      )
+    end
+
+    def mappings_into(group)
+      Actors::Mapping.where(parent: group, map_actor: user.actor)
+    end
+
+    context 'when the tenant has the system group standard_user' do
+      let!(:standard_group) do
+        Actors::Group.create!(name: 'standard_user', parent: tenant_profiles, system: true)
+      end
+
+      it 'maps the user into standard_user' do
+        expect { invite.accept! }.to change { mappings_into(standard_group).count }.from(0).to(1)
+      end
+
+      it 'marks the invite as accepted' do
+        invite.accept!
+
+        expect(invite.reload.done).to be(true)
+        expect(invite.accepted_at).to be_present
+      end
+
+      it 'does not map the user twice when accepted again' do
+        invite.accept!
+        invite.accept!
+
+        expect(mappings_into(standard_group).count).to eq(1)
+      end
+    end
+
+    context 'when the tenant has no standard_user group' do
+      it 'does not accept the invite, so the next login retries it' do
+        allow(Sentry).to receive(:capture_message)
+
+        expect(invite.accept!).to be(false)
+        expect(invite.reload.done).to be(false)
+        expect(invite.accepted_at).to be_nil
+      end
+
+      it 'reports the misconfigured tenant' do
+        expect(Sentry).to receive(:capture_message).with(/standard_user/, hash_including(level: :error))
+
+        invite.accept!
+      end
+
+      it 'does not raise, so the login flow stays usable' do
+        allow(Sentry).to receive(:capture_message)
+
+        expect { invite.accept! }.not_to raise_error
+      end
+    end
+
+    # the `system: true` filter is deliberate - a customer-created group of the same
+    # name must not be able to hand out the samedis-care-employee role
+    context 'when standard_user exists but is not a system group' do
+      # created as a system group and then flipped via #set: Actors::Group#safe_role_ids
+      # validates non-system groups against the tenant's actor defaults, which are not
+      # seeded in the test database
+      let!(:custom_group) do
+        Actors::Group.create!(name: 'standard_user', parent: tenant_profiles, system: true)
+                     .tap { |g| g.set(system: false) }
+      end
+
+      it 'ignores it and leaves the invite retryable' do
+        allow(Sentry).to receive(:capture_message)
+
+        expect(invite.accept!).to be(false)
+        expect(mappings_into(custom_group).count).to eq(0)
+        expect(invite.reload.done).to be(false)
+      end
+    end
+  end
+
+  # #accept! only marks an invite done when the processor reports success, so cover
+  # that the other processor still burns its invite
+  describe "#accept! with invitable_type 'access_control'" do
+    subject(:invite) do
+      Invite.create!(
+        email: email,
+        tenant: tenant,
+        invitable_type: 'access_control',
+        invitable_id: tenant.id.to_s,
+        actions: {},
+        auto_accept: true,
+        valid_until: 1.day.from_now
+      )
+    end
+
+    it 'marks the invite as accepted' do
+      invite.accept!
+
+      expect(invite.reload.done).to be(true)
+    end
+  end
+end

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -138,6 +138,21 @@ RSpec.describe Invite, type: :model do
       end
     end
 
+    # `no organization` and `app declares no tenant_profiles` both surface as a nil from
+    # Actors::Tenant#profiles_ou_defaults, but only the second says anything about the app.
+    # A tenant whose organization node was soft-deleted must still be reported rather than
+    # silently accepted - and note the sibling spec above reaches the Sentry branch through
+    # the rescue in #standard_user_expected?, not through this distinction
+    context 'when the tenant has no organization node' do
+      it 'treats the group as expected and reports it' do
+        allow_any_instance_of(Actors::Tenant).to receive(:organization).and_return(nil)
+
+        expect(Sentry).to receive(:capture_message).with(/standard_user/, any_args)
+        expect(invite.accept!).to be(false)
+        expect(invite.reload.done).to be(false)
+      end
+    end
+
     # invitable_type 'tenant' is settable for any app's tenant, and other apps declare
     # other groups - identity-management has no tenant_profiles OU at all - so a missing
     # standard_user group is not a misconfiguration there


### PR DESCRIPTION
Fixes Samedis-care/samedis-care-issues#2403

## Problem

`Invite#_process_accept_tenant` had an inverted guard:

```ruby
standard_group.map_into!(user.actor) unless standard_group.is_a?(Actor)
```

The mapping was skipped exactly when the group **was** found — which is always, since
`standard_user` comes from `config/apps/samedis-care/actor_defaults/samedis-care.yml`
and gets `system: true` by default (`actor.rb:919`, the YAML sets no `system:` key).

Consequence: Samedis.care's "auto join facility" feature (`Staff#login_allowed`) linked
the staff record to the user account, but the user got no group membership and therefore
no `samedis-care-employee` role. `accept!` still set `accepted_at` / `done: true`, so the
next login did not retry it. Silent, no exception, no log entry.

Introduced by 635b04f during the `employee` → `standard_user` rename, which dropped the
preceding `raise 'NO EMPLOYEE GROUP FOUND' unless employee_group.is_a?(Actor)` and folded
the negated condition onto the `map_into!` line.

Reproduced in the test environment before the fix: `accept! => true`, `done = true`,
`Actors::Mapping` count `0`.

## Fix

1. `_process_accept_tenant` — guard flipped, `map_into!` runs when the group is present.
2. `accept!` — only marks an invite `done` when the processor reports success, so a failed
   attempt stays retryable instead of being accepted for nothing.

The group name and the `system: true` filter are unchanged; only the guard was wrong.

### Why a missing group reports instead of raising

The issue left this open, and the pre-635b04f code raised. Raising is not safe here:
`accept!` runs inside the login flow via `User#auto_accept_invites!` ←
`User#check_acceptances` (`user.rb:837`) and
`Api::V1::Devise::OmniauthCallbacksController` (`:53`), **with no rescue on either path**.
An exception would lock the user out of logging in entirely rather than out of one
facility — worse than the bug being fixed.

So a misconfigured tenant now gets `Sentry.capture_message(level: :error)` and the invite
is left unaccepted. Combined with change 2 this satisfies the issue's requirement that it
must not silently mark the invite accepted while granting nothing.

Both `_process_accept_*` methods (there are only two) end in an explicit `true`, so
change 2 alters nothing on the working paths — a spec covers the `access_control` path to
keep it that way.

## Tests

`spec/models/invite_spec.rb` — the first `Invite` spec in this repo. Real Mongoid
documents, following `spec/models/actors/tenant_spec.rb`. Builds tenant → organization →
`tenant_profiles` OU → group and covers:

- the user is mapped into `standard_user`, invite marked accepted
- no double mapping when accepted again
- missing group: not accepted, no raise, reported to Sentry
- `standard_user` that is not a system group is ignored
- `access_control` invites still get accepted

Verified to fail 6/8 on the unfixed code (including the core mapping example).

Suite: **106 examples / 19 failures** on this branch vs **98 / 19 on clean main** — the
same pre-existing failures in `social_auth_controller_spec` and
`omniauth_callbacks_controller_spec` (`ActionController::UrlGenerationError`, routing,
untouched here). All 8 new examples pass.

## Review notes / follow-ups (not in this PR)

- **Not asserted:** the resulting `samedis-care-employee` role. `Role belongs_to
  :actors_app` and `User#candos` go through a cached tenant-cando aggregation, so this
  needs the full samedis-care app config seeded into the test DB; it would test the role
  engine rather than this guard.
- **Not verified against production:** that every tenant actually has the `standard_user`
  system group. The Sentry path makes a wrong assumption visible instead of fatal.
- **Existing affected users are not repaired by this.** Their invites are `done: true`.
  `Staff#needs_auto_join_invite?` gates on `email_user.tenant_ids`, which never got
  populated, so a staff re-save creates a fresh invite and now works — but nothing
  re-saves on its own. A backfill belongs in `samedis-care-backend`.
- **Adjacent latent bug, deliberately out of scope:** `raise 'NO SUCH TENANT TO JOIN'` /
  `'NO SUCH USER'` (`invite.rb:111-114`) carry the same login-lockout hazard — a deleted
  tenant with a lingering `auto_accept` invite permanently 500s that user's login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)