### PR TITLE
Block untrusted libvips loaders and validate image upload MIME types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,9 @@ gem 'shrine-mongoid'
 
 # For imageprocessing in shrine uploaders
 gem 'image_processing'
+# used directly by DeviseMailer#build_logo to sniff the configured mail logo;
+# otherwise only a transitive dependency (activestorage, which we do not load)
+gem 'marcel'
 gem 'ruby-vips'
 
 # HTTP client for microservice communication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -579,6 +579,7 @@ DEPENDENCIES
   jsonapi-serializer
   kaminari-mongoid
   listen
+  marcel
   maxminddb
   mongo_logs_on_roids
   mongoid

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,5 +1,15 @@
+require 'marcel'
+
 class DeviseMailer < Devise::Mailer
   layout 'mailer'
+
+  # app.config.mailer.logo_b64 is client-settable (Api::V1::AppAdminController
+  # permits it) and #logo hands it straight to libvips with no uploader in front,
+  # so it needs its own content check: config/initializers/vips.rb re-enables the
+  # SVG loader process-wide for the image uploaders, and without this gate an app
+  # admin could store an SVG that librsvg parses during mail rendering.
+  # Both AppAdminSerializer and AppInfoSerializer document the field as a PNG.
+  LOGO_MIME_TYPES = %w[image/png image/jpeg].freeze
 
   def unlock_instructions(user, token, opts = {})
     headers ApplicationMailer.default_headers
@@ -206,6 +216,18 @@ class DeviseMailer < Devise::Mailer
       _tmp.binmode
       _tmp.write _file.read
       _tmp.try :rewind
+
+      # Sniffed, not the content type Base64StringIO carried over from the data
+      # URI — that one is whatever the client declared.
+      _mime_type = Marcel::MimeType.for(_tmp)
+      unless LOGO_MIME_TYPES.include?(_mime_type)
+        Rails.logger.warn("DeviseMailer: ignoring mail logo of type #{_mime_type.inspect}")
+        _tmp.close
+        _tmp.delete
+        return nil
+      end
+      _tmp.try :rewind
+
       _logo = Vips::Image.new_from_file _tmp.path
       attachments.inline['logo.png'] = _tmp.read
       _tmp.close

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -8,8 +8,19 @@ class DeviseMailer < Devise::Mailer
   # so it needs its own content check: config/initializers/vips.rb re-enables the
   # SVG loader process-wide for the image uploaders, and without this gate an app
   # admin could store an SVG that librsvg parses during mail rendering.
-  # Both AppAdminSerializer and AppInfoSerializer document the field as a PNG.
-  LOGO_MIME_TYPES = %w[image/png image/jpeg].freeze
+  #
+  # Everything libvips reads with a fuzzed (trusted) loader, i.e. the uploader
+  # allowlist minus SVG — librsvg is exactly the loader that must not be reachable
+  # from here. Deliberately not narrower than that: until now the only gate on this
+  # path was libvips itself, so GIF, TIFF, WebP and HEIC logos rendered, and
+  # rejecting them here would make a working logo vanish from every mail with
+  # nothing but a log line to say why. The serializers document the field as a PNG,
+  # but nothing has ever enforced that — Actors::App::Config::Mailer#logo_b64=
+  # stores whatever the admin picked in the UI.
+  #
+  # Pre-existing quirk this does not address: attachments.inline hardcodes
+  # 'logo.png', so a JPEG or GIF logo is declared to the client as image/png.
+  LOGO_MIME_TYPES = (ImageUploader::MIME_TYPES - ['image/svg+xml']).freeze
 
   def unlock_instructions(user, token, opts = {})
     headers ApplicationMailer.default_headers
@@ -204,45 +215,23 @@ class DeviseMailer < Devise::Mailer
     @app ||= Actors::App.named(app_context).first
   end
 
+  # defined?, not ||=: nil is a meaningful result here (no logo configured, or one
+  # LOGO_MIME_TYPES rejects), and prepare_logo -> logo_size ->
+  # logo_width/height/style each re-enter this method. Without memoising nil, one
+  # rejected logo cost five base64 decodes of up to 1 MB, five Tempfiles, five
+  # marcel sniffs and five identical warnings on every mail that app sends.
   def logo
-    @logo ||= begin
-      _logo_b64 = app.config.try(:mailer).try(:logo_b64) rescue nil
-      return nil unless _logo_b64.present?
+    return @logo if defined?(@logo)
 
-      _file = Base64StringIO.from_base64(_logo_b64, 'logo')
-      _file.try :rewind
-      _file.binmode
-      _tmp = Tempfile.new(_file.original_filename)
-      _tmp.binmode
-      _tmp.write _file.read
-      _tmp.try :rewind
-
-      # Sniffed, not the content type Base64StringIO carried over from the data
-      # URI — that one is whatever the client declared.
-      _mime_type = Marcel::MimeType.for(_tmp)
-      unless LOGO_MIME_TYPES.include?(_mime_type)
-        Rails.logger.warn("DeviseMailer: ignoring mail logo of type #{_mime_type.inspect}")
-        _tmp.close
-        _tmp.delete
-        return nil
-      end
-      _tmp.try :rewind
-
-      _logo = Vips::Image.new_from_file _tmp.path
-      attachments.inline['logo.png'] = _tmp.read
-      _tmp.close
-      _tmp.delete
-      _logo
-    end
+    @logo = build_logo
   end
 
   def logo_size
-    @logo_size ||= begin
-      width = 250
-      _logo = logo
-      return "" if _logo.nil?
-      "#{width}x#{(_logo.height / (_logo.width.to_f / width)).to_i}"
-    end
+    return @logo_size if defined?(@logo_size) # same reason as #logo
+
+    width = 250
+    _logo = logo
+    @logo_size = _logo.nil? ? '' : "#{width}x#{(_logo.height / (_logo.width.to_f / width)).to_i}"
   end
 
   def logo_width
@@ -262,6 +251,36 @@ class DeviseMailer < Devise::Mailer
       _width, _height = logo_size.split('x')
       "width:#{_width}px; height:#{_height}px;"
     end
+  end
+
+  def build_logo
+    _logo_b64 = app.config.try(:mailer).try(:logo_b64) rescue nil
+    return nil unless _logo_b64.present?
+
+    _file = Base64StringIO.from_base64(_logo_b64, 'logo')
+    _file.try :rewind
+    _file.binmode
+    _tmp = Tempfile.new(_file.original_filename)
+    _tmp.binmode
+    _tmp.write _file.read
+    _tmp.try :rewind
+
+    # Sniffed, not the content type Base64StringIO carried over from the data
+    # URI — that one is whatever the client declared.
+    _mime_type = Marcel::MimeType.for(_tmp)
+    unless LOGO_MIME_TYPES.include?(_mime_type)
+      Rails.logger.warn("DeviseMailer: ignoring mail logo of type #{_mime_type.inspect}")
+      _tmp.close
+      _tmp.delete
+      return nil
+    end
+    _tmp.try :rewind
+
+    _logo = Vips::Image.new_from_file _tmp.path
+    attachments.inline['logo.png'] = _tmp.read
+    _tmp.close
+    _tmp.delete
+    _logo
   end
 
   def prepare_logo

--- a/app/uploaders/actor_image_uploader.rb
+++ b/app/uploaders/actor_image_uploader.rb
@@ -11,11 +11,12 @@ class ActorImageUploader < Shrine
   plugin :validation_helpers
 
   Attacher.validate do
-    # Only formats we actually render derivatives for. Without this, arbitrary
-    # uploaded bytes reach libvips and the loader is picked by content sniffing —
-    # see config/initializers/vips.rb (CVE-2026-66066). The MIME type comes from
+    # Same allowlist as ImageUploader, deliberately shared rather than copied so
+    # the two cannot drift: both feed the same libvips loaders, and the reasoning
+    # behind the list lives on ImageUploader::MIME_TYPES
+    # (config/initializers/vips.rb, CVE-2026-66066). The MIME type comes from
     # marcel content analysis, not from the client-supplied header.
-    validate_mime_type_inclusion %w[image/png image/jpeg image/svg+xml]
+    validate_mime_type_inclusion ImageUploader::MIME_TYPES
   end
 
   add_metadata do |io, context|

--- a/app/uploaders/actor_image_uploader.rb
+++ b/app/uploaders/actor_image_uploader.rb
@@ -8,6 +8,15 @@ class ActorImageUploader < Shrine
   plugin :add_metadata
   plugin :determine_mime_type, analyzer: :marcel
   plugin :derivatives, versions_compatibility: true
+  plugin :validation_helpers
+
+  Attacher.validate do
+    # Only formats we actually render derivatives for. Without this, arbitrary
+    # uploaded bytes reach libvips and the loader is picked by content sniffing —
+    # see config/initializers/vips.rb (CVE-2026-66066). The MIME type comes from
+    # marcel content analysis, not from the client-supplied header.
+    validate_mime_type_inclusion %w[image/png image/jpeg image/svg+xml]
+  end
 
   add_metadata do |io, context|
     filename = context[:record].id

--- a/app/uploaders/actor_image_uploader.rb
+++ b/app/uploaders/actor_image_uploader.rb
@@ -9,6 +9,9 @@ class ActorImageUploader < Shrine
   plugin :determine_mime_type, analyzer: :marcel
   plugin :derivatives, versions_compatibility: true
   plugin :validation_helpers
+  # See ImageUploader: `model, cache: false` uploads to :store before validating,
+  # so rejected files need destroying or they stay in the bucket unreferenced.
+  plugin :remove_invalid
 
   Attacher.validate do
     # Same allowlist as ImageUploader, deliberately shared rather than copied so

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -8,6 +8,15 @@ class ImageUploader < Shrine
   plugin :add_metadata
   plugin :determine_mime_type, analyzer: :marcel
   plugin :derivatives, versions_compatibility: true
+  plugin :validation_helpers
+
+  Attacher.validate do
+    # Only formats we actually render derivatives for. Without this, arbitrary
+    # uploaded bytes reach libvips and the loader is picked by content sniffing —
+    # see config/initializers/vips.rb (CVE-2026-66066). The MIME type comes from
+    # marcel content analysis, not from the client-supplied header.
+    validate_mime_type_inclusion %w[image/png image/jpeg image/svg+xml]
+  end
 
   add_metadata do |io, context|
     filename = context[:record].id

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -10,12 +10,34 @@ class ImageUploader < Shrine
   plugin :derivatives, versions_compatibility: true
   plugin :validation_helpers
 
+  # Formats libvips can read with a fuzzed (trusted) loader, plus SVG, which
+  # config/initializers/vips.rb re-enables deliberately. Without this list,
+  # arbitrary uploaded bytes reach libvips and the loader is picked by content
+  # sniffing — see that initializer and CVE-2026-66066. None of these loaders is
+  # part of libvips' untrusted set, so allowing them costs nothing against the
+  # CVE; what the list buys is rejecting content that is not an image at all,
+  # with a clean validation error. HEIC/HEIF/AVIF and WebP matter because avatars
+  # come off phones, GIF and TIFF because they were uploadable before this list
+  # existed and turning a working upload into an error is the worse failure.
+  #
+  # The MIME type comes from marcel content analysis (determine_mime_type
+  # plugin), not from the client-supplied header — which matters for
+  # User#image_b64= and Actor#image_b64=, where Base64StringIO carries the
+  # content type the client declared in the data URI.
+  MIME_TYPES = %w[
+    image/png
+    image/jpeg
+    image/svg+xml
+    image/heic
+    image/heif
+    image/avif
+    image/webp
+    image/gif
+    image/tiff
+  ].freeze
+
   Attacher.validate do
-    # Only formats we actually render derivatives for. Without this, arbitrary
-    # uploaded bytes reach libvips and the loader is picked by content sniffing —
-    # see config/initializers/vips.rb (CVE-2026-66066). The MIME type comes from
-    # marcel content analysis, not from the client-supplied header.
-    validate_mime_type_inclusion %w[image/png image/jpeg image/svg+xml]
+    validate_mime_type_inclusion ImageUploader::MIME_TYPES
   end
 
   add_metadata do |io, context|

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -12,6 +12,13 @@ class ImageUploader < Shrine
   # With `model, cache: false` an assignment uploads to permanent :store before
   # the validation below runs, so a rejected file would sit in the bucket
   # unreferenced forever — the record never saves. remove_invalid destroys it.
+  # Precisely: it reverts the *attacher* (record.image is the previous file again,
+  # the rejected object is deleted) but never writes through to the model, because
+  # deassign uses load_data rather than set. So record.image_data still holds the
+  # deleted file's JSON in memory. Harmless while the attacher's errors keep the
+  # record from saving — the trap is a save(validate: false) on the same in-memory
+  # record, e.g. User#tenant_access_group_ids, which would persist a reference to a
+  # deleted key.
   plugin :remove_invalid
 
   # Formats libvips can read with a fuzzed (trusted) loader, plus SVG, which

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -9,6 +9,10 @@ class ImageUploader < Shrine
   plugin :determine_mime_type, analyzer: :marcel
   plugin :derivatives, versions_compatibility: true
   plugin :validation_helpers
+  # With `model, cache: false` an assignment uploads to permanent :store before
+  # the validation below runs, so a rejected file would sit in the bucket
+  # unreferenced forever — the record never saves. remove_invalid destroys it.
+  plugin :remove_invalid
 
   # Formats libvips can read with a fuzzed (trusted) loader, plus SVG, which
   # config/initializers/vips.rb re-enables deliberately. Without this list,

--- a/config/initializers/vips.rb
+++ b/config/initializers/vips.rb
@@ -29,10 +29,14 @@ Vips.block_untrusted(true)
 # every other untrusted loader/saver (BMP, ICO, PSD, JPEG XL, JPEG 2000, Netpbm,
 # FITS, Matlab, OpenSlide, anything delegated to ImageMagick) stays blocked.
 #
-# ImageUploader and ActorImageUploader validate against a png/jpeg/svg allowlist
-# with content sniffing (marcel) before any of this runs, so only content that
-# actually looks like SVG reaches librsvg. To drop SVG support entirely, delete
-# this block and remove image/svg+xml from both uploaders.
+# ImageUploader and ActorImageUploader both validate against
+# ImageUploader::MIME_TYPES with content sniffing (marcel) before any of this
+# runs, so only content that actually looks like SVG reaches librsvg — including
+# on the User#image_b64= / Actor#image_b64= paths, where the content type the
+# client declared in the data URI is not what gets validated.
+#
+# To drop SVG support entirely, delete this block and remove image/svg+xml from
+# ImageUploader::MIME_TYPES.
 %w[
   VipsForeignLoadSvgFile
   VipsForeignLoadSvgBuffer

--- a/config/initializers/vips.rb
+++ b/config/initializers/vips.rb
@@ -1,0 +1,40 @@
+# libvips reads and writes formats through "loaders" and "savers", some of which
+# it flags as "unfuzzed"/untrusted: they are backed by third-party libraries that
+# are only safe for trusted content. Feeding attacker-supplied files to them can
+# disclose arbitrary files readable by this process, potentially RCE.
+# See CVE-2026-66066 / GHSA-xr9x-r78c-5hrm — reported against Active Storage,
+# which we do not load (see config/application.rb); the underlying problem is
+# libvips, which we do use.
+#
+# image_processing 2.0 already calls Vips.block_untrusted(true) when
+# image_processing/vips is required, but not every path into libvips goes through
+# that gem: DeviseMailer#logo hands the app's configured logo_b64 straight to
+# Vips::Image.new_from_file. Blocking here makes it explicit and independent of
+# load order.
+#
+# Requiring image_processing/vips first is deliberate: that require calls
+# block_untrusted itself, which re-blocks the SVG loaders re-enabled below. The
+# require is idempotent, so the uploaders' own requires are no-ops and cannot
+# undo this.
+require 'image_processing/vips'
+
+unless Vips.at_least_libvips?(8, 13)
+  raise "libvips #{Vips.version_string} cannot block untrusted operations — 8.13 or newer is required"
+end
+
+Vips.block_untrusted(true)
+
+# The SVG loader (librsvg) is one of the untrusted ones, but SVG is an accepted
+# upload format for user and actor images. Re-enable just those three loaders;
+# every other untrusted loader/saver (BMP, ICO, PSD, JPEG XL, JPEG 2000, Netpbm,
+# FITS, Matlab, OpenSlide, anything delegated to ImageMagick) stays blocked.
+#
+# ImageUploader and ActorImageUploader validate against a png/jpeg/svg allowlist
+# with content sniffing (marcel) before any of this runs, so only content that
+# actually looks like SVG reaches librsvg. To drop SVG support entirely, delete
+# this block and remove image/svg+xml from both uploaders.
+%w[
+  VipsForeignLoadSvgFile
+  VipsForeignLoadSvgBuffer
+  VipsForeignLoadSvgSource
+].each { |loader| Vips.block(loader, false) }

--- a/config/initializers/vips.rb
+++ b/config/initializers/vips.rb
@@ -25,9 +25,16 @@ end
 Vips.block_untrusted(true)
 
 # The SVG loader (librsvg) is one of the untrusted ones, but SVG is an accepted
-# upload format for user and actor images. Re-enable just those three loaders;
-# every other untrusted loader/saver (BMP, ICO, PSD, JPEG XL, JPEG 2000, Netpbm,
-# FITS, Matlab, OpenSlide, anything delegated to ImageMagick) stays blocked.
+# upload format for user and actor images. Re-enable it; every other untrusted
+# loader/saver (BMP, ICO, PSD, JPEG XL, JPEG 2000, Netpbm, FITS, Matlab,
+# OpenSlide, anything delegated to ImageMagick) stays blocked. Naming the parent
+# class covers the file, buffer and source variants — vips_operation_block_set
+# applies to the named class and everything below it.
+#
+# This is process-wide, not per-uploader, so every caller that reaches libvips
+# needs its own content check, not just the uploaders — see
+# DeviseMailer::LOGO_MIME_TYPES for the mail logo, which has no uploader in front
+# of it.
 #
 # ImageUploader and ActorImageUploader both validate against
 # ImageUploader::MIME_TYPES with content sniffing (marcel) before any of this
@@ -37,8 +44,7 @@ Vips.block_untrusted(true)
 #
 # To drop SVG support entirely, delete this block and remove image/svg+xml from
 # ImageUploader::MIME_TYPES.
-%w[
-  VipsForeignLoadSvgFile
-  VipsForeignLoadSvgBuffer
-  VipsForeignLoadSvgSource
-].each { |loader| Vips.block(loader, false) }
+# NOTE: Vips.block is a no-op for an unknown operation name, so a typo or a
+# libvips built without librsvg fails silently — SVG simply stays blocked.
+# spec/lib/vips_blocking_spec.rb is what catches that.
+Vips.block('VipsForeignLoadSvg', false)

--- a/spec/lib/vips_blocking_spec.rb
+++ b/spec/lib/vips_blocking_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+# Guards config/initializers/vips.rb (CVE-2026-66066 / GHSA-xr9x-r78c-5hrm).
+#
+# The load order is the fragile part: image_processing/vips calls
+# Vips.block_untrusted(true) whenever it is required, which re-blocks the SVG
+# loaders the initializer re-enables. The initializer therefore requires
+# image_processing/vips itself, before unblocking SVG. Touching the uploaders
+# here re-triggers that require the way eager loading does in production.
+describe 'libvips untrusted operation blocking', type: :model do
+  def svg(size)
+    %(<svg xmlns="http://www.w3.org/2000/svg" width="#{size}" height="#{size}">) +
+      %(<rect width="#{size}" height="#{size}"/></svg>)
+  end
+
+  def tempfile(bytes, extension)
+    file = Tempfile.new(['vips-blocking', extension])
+    file.binmode
+    file.write(bytes)
+    file.rewind
+    file
+  end
+
+  def loadable?(file)
+    Vips::Image.new_from_file(file.path).avg
+    true
+  rescue Vips::Error
+    false
+  end
+
+  before { [ImageUploader, ActorImageUploader].each(&:name) }
+
+  it 'blocks untrusted loaders' do
+    # Netpbm stands in for the whole untrusted set (BMP, ICO, PSD, JPEG XL,
+    # JPEG 2000, FITS, Matlab, OpenSlide, ImageMagick delegates).
+    expect(loadable?(tempfile("P3\n1 1\n255\n0 0 0\n", '.ppm'))).to be false
+  end
+
+  it 'still allows the SVG loader, which user and actor images accept' do
+    expect(loadable?(tempfile(svg(4), '.svg'))).to be true
+  end
+
+  it 'still allows PNG' do
+    expect(loadable?(tempfile(Vips::Image.black(4, 4).write_to_buffer('.png'), '.png'))).to be true
+  end
+
+  it 'still allows JPEG' do
+    expect(loadable?(tempfile(Vips::Image.black(4, 4).write_to_buffer('.jpg'), '.jpg'))).to be true
+  end
+
+  it 'processes an SVG through the uploader pipeline' do
+    source = tempfile(svg(40), '.svg').path
+    processed = ImageProcessing::Vips.source(source).resize_to_limit(20, 20).convert('png').call
+    expect(File.size(processed.path)).to be > 0
+  end
+end

--- a/spec/lib/vips_blocking_spec.rb
+++ b/spec/lib/vips_blocking_spec.rb
@@ -32,7 +32,21 @@ describe 'libvips untrusted operation blocking', type: :model do
   it 'blocks untrusted loaders' do
     # Netpbm stands in for the whole untrusted set (BMP, ICO, PSD, JPEG XL,
     # JPEG 2000, FITS, Matlab, OpenSlide, ImageMagick delegates).
-    expect(loadable?(tempfile("P3\n1 1\n255\n0 0 0\n", '.ppm'))).to be false
+    file = tempfile("P3\n1 1\n255\n0 0 0\n", '.ppm')
+
+    # Positive control: libvips reports a blocked loader and a loader that was
+    # never compiled in through the same "not a known file format" error, so
+    # without this the assertion below would be green on a build without
+    # ppmload — passing for the wrong reason on the one thing that matters here.
+    begin
+      Vips.block('VipsForeignLoadPpm', false)
+      expect(loadable?(file)).to be(true),
+                                 'ppmload is missing from this libvips build, so the block assertion proves nothing'
+    ensure
+      Vips.block('VipsForeignLoadPpm', true)
+    end
+
+    expect(loadable?(file)).to be false
   end
 
   it 'still allows the SVG loader, which user and actor images accept' do
@@ -48,14 +62,19 @@ describe 'libvips untrusted operation blocking', type: :model do
   end
 
   it 'still allows the camera formats in ImageUploader::MIME_TYPES' do
-    %w[.heic .webp].each do |extension|
+    checked = %w[.heic .webp].filter_map do |extension|
       begin
         bytes = Vips::Image.black(4, 4).write_to_buffer(extension)
       rescue Vips::Error
         next # saver not compiled in here; the loader is what production needs
       end
       expect(loadable?(tempfile(bytes, extension))).to be(true), "#{extension} should still load"
+      extension
     end
+
+    # Otherwise this passes vacuously on a build with neither saver, and the run
+    # output looks identical to a real check.
+    skip 'neither .heic nor .webp can be written by this libvips build' if checked.empty?
   end
 
   it 'processes an SVG through the uploader pipeline' do

--- a/spec/lib/vips_blocking_spec.rb
+++ b/spec/lib/vips_blocking_spec.rb
@@ -2,11 +2,12 @@ require 'rails_helper'
 
 # Guards config/initializers/vips.rb (CVE-2026-66066 / GHSA-xr9x-r78c-5hrm).
 #
-# The load order is the fragile part: image_processing/vips calls
-# Vips.block_untrusted(true) whenever it is required, which re-blocks the SVG
-# loaders the initializer re-enables. The initializer therefore requires
-# image_processing/vips itself, before unblocking SVG. Touching the uploaders
-# here re-triggers that require the way eager loading does in production.
+# The load order inside that initializer is the fragile part: requiring
+# image_processing/vips calls Vips.block_untrusted(true), which re-blocks the SVG
+# loaders the initializer re-enables — so the require has to come first and the
+# unblock last. What guards that here is the initializer itself: it runs at boot
+# in the same order as in production, so reordering it (unblock before require)
+# leaves SVG blocked and the SVG examples below fail.
 describe 'libvips untrusted operation blocking', type: :model do
   def svg(size)
     %(<svg xmlns="http://www.w3.org/2000/svg" width="#{size}" height="#{size}">) +
@@ -28,8 +29,6 @@ describe 'libvips untrusted operation blocking', type: :model do
     false
   end
 
-  before { [ImageUploader, ActorImageUploader].each(&:name) }
-
   it 'blocks untrusted loaders' do
     # Netpbm stands in for the whole untrusted set (BMP, ICO, PSD, JPEG XL,
     # JPEG 2000, FITS, Matlab, OpenSlide, ImageMagick delegates).
@@ -48,9 +47,22 @@ describe 'libvips untrusted operation blocking', type: :model do
     expect(loadable?(tempfile(Vips::Image.black(4, 4).write_to_buffer('.jpg'), '.jpg'))).to be true
   end
 
+  it 'still allows the camera formats in ImageUploader::MIME_TYPES' do
+    %w[.heic .webp].each do |extension|
+      begin
+        bytes = Vips::Image.black(4, 4).write_to_buffer(extension)
+      rescue Vips::Error
+        next # saver not compiled in here; the loader is what production needs
+      end
+      expect(loadable?(tempfile(bytes, extension))).to be(true), "#{extension} should still load"
+    end
+  end
+
   it 'processes an SVG through the uploader pipeline' do
-    source = tempfile(svg(40), '.svg').path
-    processed = ImageProcessing::Vips.source(source).resize_to_limit(20, 20).convert('png').call
+    # Keep the Tempfile referenced: its finalizer unlinks the file on GC, and
+    # libvips only opens it inside #call.
+    source = tempfile(svg(40), '.svg')
+    processed = ImageProcessing::Vips.source(source.path).resize_to_limit(20, 20).convert('png').call
     expect(File.size(processed.path)).to be > 0
   end
 end

--- a/spec/mailers/devise_mailer_logo_spec.rb
+++ b/spec/mailers/devise_mailer_logo_spec.rb
@@ -35,4 +35,28 @@ describe DeviseMailer, type: :mailer do
     mailer.send(:logo)
     expect(mailer.attachments['logo.png']).to be_nil
   end
+
+  it 'accepts a GIF, which rendered fine before this gate existed' do
+    stub_logo(Vips::Image.black(8, 8).write_to_buffer('.gif'), 'image/gif')
+    expect(mailer.send(:logo)).to be_a(Vips::Image)
+  rescue Vips::Error
+    skip 'this libvips build cannot write GIF'
+  end
+
+  # prepare_logo -> logo_size -> logo_width/height/style each call #logo, so a
+  # rejection that does not memoise costs five base64 decodes, five Tempfiles,
+  # five marcel sniffs and five identical warnings for every mail that app sends.
+  it 'builds the logo once even when it is rejected' do
+    stub_logo("P3\n1 1\n255\n0 0 0\n", 'image/png')
+    allow(mailer).to receive(:build_logo).and_call_original
+    mailer.send(:prepare_logo)
+    expect(mailer).to have_received(:build_logo).once
+  end
+
+  it 'builds the logo once when it is accepted' do
+    stub_logo(Vips::Image.black(8, 8).write_to_buffer('.png'), 'image/png')
+    allow(mailer).to receive(:build_logo).and_call_original
+    mailer.send(:prepare_logo)
+    expect(mailer).to have_received(:build_logo).once
+  end
 end

--- a/spec/mailers/devise_mailer_logo_spec.rb
+++ b/spec/mailers/devise_mailer_logo_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+# app.config.mailer.logo_b64 is client-settable (Api::V1::AppAdminController
+# permits it) and #logo hands it to libvips with no uploader in front, so it needs
+# its own MIME gate: config/initializers/vips.rb re-enables the SVG loader
+# process-wide, which would otherwise let an app admin have librsvg parse an SVG
+# during mail rendering.
+describe DeviseMailer, type: :mailer do
+  let(:mailer) { described_class.new }
+
+  def stub_logo(bytes, declared_mime)
+    b64 = "data:#{declared_mime};base64,#{Base64.strict_encode64(bytes)}"
+    app = OpenStruct.new(config: OpenStruct.new(mailer: OpenStruct.new(logo_b64: b64)))
+    allow(mailer).to receive(:app).and_return(app)
+  end
+
+  it 'loads a PNG logo' do
+    stub_logo(Vips::Image.black(8, 8).write_to_buffer('.png'), 'image/png')
+    expect(mailer.send(:logo)).to be_a(Vips::Image)
+  end
+
+  it 'ignores an SVG logo even though the SVG loader is unblocked' do
+    svg = '<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><rect width="8" height="8"/></svg>'
+    stub_logo(svg, 'image/svg+xml')
+    expect(mailer.send(:logo)).to be_nil
+  end
+
+  it 'ignores a logo whose declared image/png contradicts its content' do
+    stub_logo("%PDF-1.4\n1 0 obj\n<< >>\nendobj\ntrailer\n<< >>\n%%EOF\n", 'image/png')
+    expect(mailer.send(:logo)).to be_nil
+  end
+
+  it 'attaches nothing when the logo is rejected' do
+    stub_logo("P3\n1 1\n255\n0 0 0\n", 'image/png')
+    mailer.send(:logo)
+    expect(mailer.attachments['logo.png']).to be_nil
+  end
+end

--- a/spec/uploaders/image_uploaders_spec.rb
+++ b/spec/uploaders/image_uploaders_spec.rb
@@ -80,6 +80,36 @@ describe 'image upload MIME allowlist', type: :model do
     SVG
   end
 
+  # Encoder-independent: the HEIC/WebP examples below gate on the *saver* being
+  # compiled in, so on a libvips without a HEIF encoder they skip and nothing would
+  # notice a misspelled allowlist key. A constructed ftyp header needs no encoder.
+  #
+  # marcel 1.2.1 does have magic entries for all six HEIF brands (tables.rb
+  # 2617-2621), but magic_match takes the *first* hit and video/quicktime's generic
+  # [4, 'ftyp'] pattern (line 2530) sits ahead of the brand-specific ones — so only
+  # heic/mif1/avif resolve to an image type, while heix/hevc/msf1 come back as
+  # video/quicktime. Putting image/heic-sequence on the allowlist would therefore
+  # buy nothing, and video/quicktime has no business on an image allowlist.
+  describe 'the MIME types marcel emits for HEIF brands' do
+    { 'ftypheic' => 'image/heic', 'ftypmif1' => 'image/heif', 'ftypavif' => 'image/avif' }
+      .each do |brand, mime_type|
+        it "detects #{brand} as #{mime_type}, which is on the allowlist" do
+          io = StringIO.new("\x00\x00\x00\x18#{brand}\x00\x00\x00\x00".b)
+          expect(Marcel::MimeType.for(io)).to eq(mime_type)
+          expect(ImageUploader::MIME_TYPES).to include(mime_type)
+        end
+      end
+
+    %w[ftypheix ftyphevc ftypmsf1].each do |brand|
+      it "resolves #{brand} to video/quicktime, so the allowlist rejects it" do
+        io = StringIO.new("\x00\x00\x00\x18#{brand}\x00\x00\x00\x00".b)
+        detected = Marcel::MimeType.for(io)
+        expect(detected).to eq('video/quicktime')
+        expect(ImageUploader::MIME_TYPES).not_to include(detected)
+      end
+    end
+  end
+
   describe ImageUploader do
     let(:record)   { User.new(email: 'vips-spec@example.com') }
     let(:attacher) { record.image_attacher }

--- a/spec/uploaders/image_uploaders_spec.rb
+++ b/spec/uploaders/image_uploaders_spec.rb
@@ -32,6 +32,17 @@ describe 'image upload MIME allowlist', type: :model do
     attacher
   end
 
+  # The production path: `record.image =` goes through model_assign, which with
+  # `model, cache: false` uploads to permanent :store before validating.
+  def assign_via_model(record, bytes, filename: 'upload.png')
+    file = Tempfile.new([File.basename(filename, '.*'), File.extname(filename)])
+    file.binmode
+    file.write(bytes)
+    file.rewind
+    record.image = file
+    record
+  end
+
   def png
     Vips::Image.black(4, 4).write_to_buffer('.png')
   end
@@ -118,6 +129,20 @@ describe 'image upload MIME allowlist', type: :model do
     it 'rejects an image_b64 data URI whose declared image/png contradicts its content' do
       record.image_b64 = "data:image/png;base64,#{Base64.strict_encode64("P3\n1 1\n255\n0 0 0\n")}"
       expect(record.image_attacher.errors).not_to be_empty
+    end
+
+    # The production path is `record.image =`, which with `model, cache: false`
+    # uploads to permanent :store *before* validating. Without remove_invalid the
+    # rejected bytes would stay in the bucket forever: the record never saves, so
+    # nothing references or deletes them.
+    it 'leaves nothing in permanent storage when the upload is rejected' do
+      assign_via_model(record, pdf)
+      expect(described_class.storages[:store].store).to be_empty
+    end
+
+    it 'keeps an accepted upload in permanent storage' do
+      assign_via_model(record, png)
+      expect(described_class.storages[:store].store).not_to be_empty
     end
   end
 

--- a/spec/uploaders/image_uploaders_spec.rb
+++ b/spec/uploaders/image_uploaders_spec.rb
@@ -2,15 +2,23 @@ require 'rails_helper'
 require 'shrine/storage/memory'
 
 # CVE-2026-66066 / GHSA-xr9x-r78c-5hrm: both image uploaders accepted any content
-# type, so arbitrary uploaded bytes reached libvips with the loader chosen by
-# content sniffing. Uploads are now restricted to the formats whose derivatives
-# we actually render.
+# type — they had no validations at all — so arbitrary uploaded bytes reached
+# libvips with the loader chosen by content sniffing. Uploads are now restricted
+# to ImageUploader::MIME_TYPES.
 describe 'image upload MIME allowlist', type: :model do
+  # Shrine dups @storages into every subclass at class-definition time
+  # (shrine.rb#inherited), and both uploaders are defined after
+  # config/initializers/shrine.rb ran — so reassigning Shrine.storages would not
+  # reach them and the examples would upload to the configured FileSystem cache,
+  # leaving files in public/uploads/cache. Override on the classes under test.
   around do |example|
-    original_storages = Shrine.storages
-    Shrine.storages = { cache: Shrine::Storage::Memory.new, store: Shrine::Storage::Memory.new }
+    originals = { ImageUploader => ImageUploader.storages,
+                  ActorImageUploader => ActorImageUploader.storages }
+    originals.each_key do |klass|
+      klass.storages = { cache: Shrine::Storage::Memory.new, store: Shrine::Storage::Memory.new }
+    end
     example.run
-    Shrine.storages = original_storages
+    originals.each { |klass, storages| klass.storages = storages }
   end
 
   # Uploads bytes under a *harmless* extension on purpose: the allowlist has to
@@ -28,12 +36,37 @@ describe 'image upload MIME allowlist', type: :model do
     Vips::Image.black(4, 4).write_to_buffer('.png')
   end
 
+  # HEIF/AVIF/WebP savers are optional in a libvips build, so a machine that
+  # cannot write the fixture skips instead of failing. The loaders are what
+  # matters in production and they are not part of the untrusted set.
+  def image_buffer(extension)
+    Vips::Image.black(4, 4).write_to_buffer(extension)
+  rescue Vips::Error
+    skip "libvips #{Vips.version_string} cannot write #{extension} here"
+  end
+
   def svg
     '<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4"><rect width="4" height="4"/></svg>'
   end
 
   def pdf
     "%PDF-1.4\n1 0 obj\n<< >>\nendobj\ntrailer\n<< >>\n%%EOF\n"
+  end
+
+  # Designer export: XML prolog, generator comment, DOCTYPE and editor namespaces
+  # push <svg> to roughly offset 250.
+  def designer_svg
+    <<~SVG
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <!-- Generator: Adobe Illustrator 28.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+      <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+      <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg"
+           xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 200 100"
+           style="enable-background:new 0 0 200 100;" xml:space="preserve">
+        <style type="text/css">.st0{fill:#004E7D;}</style>
+        <rect class="st0" width="200" height="100"/>
+      </svg>
+    SVG
   end
 
   describe ImageUploader do
@@ -45,12 +78,20 @@ describe 'image upload MIME allowlist', type: :model do
     end
 
     it 'accepts JPEG' do
-      expect(assign(attacher, Vips::Image.black(4, 4).write_to_buffer('.jpg'),
-                    filename: 'upload.jpg').errors).to be_empty
+      expect(assign(attacher, image_buffer('.jpg'), filename: 'upload.jpg').errors).to be_empty
     end
 
     it 'accepts SVG' do
       expect(assign(attacher, svg, filename: 'upload.svg').errors).to be_empty
+    end
+
+    # Avatars come off phones, so the camera formats have to stay uploadable.
+    it 'accepts HEIC' do
+      expect(assign(attacher, image_buffer('.heic'), filename: 'upload.heic').errors).to be_empty
+    end
+
+    it 'accepts WebP' do
+      expect(assign(attacher, image_buffer('.webp'), filename: 'upload.webp').errors).to be_empty
     end
 
     it 'rejects a PDF even when it is named .png' do
@@ -59,6 +100,24 @@ describe 'image upload MIME allowlist', type: :model do
 
     it 'rejects a Netpbm image, whose libvips loader is untrusted' do
       expect(assign(attacher, "P3\n1 1\n255\n0 0 0\n", filename: 'upload.ppm').errors).not_to be_empty
+    end
+
+    # marcel sniffs content, and Shrine calls it without a filename, so a
+    # designer export — XML prolog, generator comment, DOCTYPE and editor
+    # namespaces before <svg> appears ~250 bytes in — has to be recognised just
+    # as well as a bare <svg ...> fixture. App logos arrive in exactly this shape.
+    it 'accepts an SVG whose <svg> element starts after a prolog and DOCTYPE' do
+      assign(attacher, designer_svg, filename: 'logo.svg')
+      expect(attacher.file.mime_type).to eq('image/svg+xml')
+      expect(attacher.errors).to be_empty
+    end
+
+    # image_b64= is the API entry point (User#image_b64=, Actor#image_b64=), and
+    # Base64StringIO keeps the content type the client declared in the data URI.
+    # The allowlist has to hold against that claim rather than trust it.
+    it 'rejects an image_b64 data URI whose declared image/png contradicts its content' do
+      record.image_b64 = "data:image/png;base64,#{Base64.strict_encode64("P3\n1 1\n255\n0 0 0\n")}"
+      expect(record.image_attacher.errors).not_to be_empty
     end
   end
 
@@ -74,8 +133,16 @@ describe 'image upload MIME allowlist', type: :model do
       expect(assign(attacher, svg, filename: 'upload.svg').errors).to be_empty
     end
 
+    it 'accepts HEIC' do
+      expect(assign(attacher, image_buffer('.heic'), filename: 'upload.heic').errors).to be_empty
+    end
+
     it 'rejects a PDF even when it is named .png' do
       expect(assign(attacher, pdf).errors).not_to be_empty
+    end
+
+    it 'shares ImageUploader::MIME_TYPES rather than keeping its own copy' do
+      expect(assign(attacher, "P3\n1 1\n255\n0 0 0\n", filename: 'upload.ppm').errors).not_to be_empty
     end
   end
 end

--- a/spec/uploaders/image_uploaders_spec.rb
+++ b/spec/uploaders/image_uploaders_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+require 'shrine/storage/memory'
+
+# CVE-2026-66066 / GHSA-xr9x-r78c-5hrm: both image uploaders accepted any content
+# type, so arbitrary uploaded bytes reached libvips with the loader chosen by
+# content sniffing. Uploads are now restricted to the formats whose derivatives
+# we actually render.
+describe 'image upload MIME allowlist', type: :model do
+  around do |example|
+    original_storages = Shrine.storages
+    Shrine.storages = { cache: Shrine::Storage::Memory.new, store: Shrine::Storage::Memory.new }
+    example.run
+    Shrine.storages = original_storages
+  end
+
+  # Uploads bytes under a *harmless* extension on purpose: the allowlist has to
+  # hold on sniffed content (marcel), not on the name the client supplied.
+  def assign(attacher, bytes, filename: 'upload.png')
+    file = Tempfile.new([File.basename(filename, '.*'), File.extname(filename)])
+    file.binmode
+    file.write(bytes)
+    file.rewind
+    attacher.assign(file)
+    attacher
+  end
+
+  def png
+    Vips::Image.black(4, 4).write_to_buffer('.png')
+  end
+
+  def svg
+    '<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4"><rect width="4" height="4"/></svg>'
+  end
+
+  def pdf
+    "%PDF-1.4\n1 0 obj\n<< >>\nendobj\ntrailer\n<< >>\n%%EOF\n"
+  end
+
+  describe ImageUploader do
+    let(:record)   { User.new(email: 'vips-spec@example.com') }
+    let(:attacher) { record.image_attacher }
+
+    it 'accepts PNG' do
+      expect(assign(attacher, png).errors).to be_empty
+    end
+
+    it 'accepts JPEG' do
+      expect(assign(attacher, Vips::Image.black(4, 4).write_to_buffer('.jpg'),
+                    filename: 'upload.jpg').errors).to be_empty
+    end
+
+    it 'accepts SVG' do
+      expect(assign(attacher, svg, filename: 'upload.svg').errors).to be_empty
+    end
+
+    it 'rejects a PDF even when it is named .png' do
+      expect(assign(attacher, pdf).errors).not_to be_empty
+    end
+
+    it 'rejects a Netpbm image, whose libvips loader is untrusted' do
+      expect(assign(attacher, "P3\n1 1\n255\n0 0 0\n", filename: 'upload.ppm').errors).not_to be_empty
+    end
+  end
+
+  describe ActorImageUploader do
+    let(:record)   { Actor.new(name: 'vips-spec') }
+    let(:attacher) { record.image_attacher }
+
+    it 'accepts PNG' do
+      expect(assign(attacher, png).errors).to be_empty
+    end
+
+    it 'accepts SVG' do
+      expect(assign(attacher, svg, filename: 'upload.svg').errors).to be_empty
+    end
+
+    it 'rejects a PDF even when it is named .png' do
+      expect(assign(attacher, pdf).errors).not_to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Fixes Samedis-care/samedis-care-issues#2451 — the IMB half of the libvips problem behind Samedis-care/samedis-care-issues#2412. Same fix as samedis-care-backend#4108.

## What this is about

CVE-2026-66066 / GHSA-xr9x-r78c-5hrm names `activestorage`. We don't load Active Storage (`config/application.rb:8`), so that path isn't exploitable — but the vulnerable component is **libvips**, and we call it for user/actor image derivatives and for the mail logo. libvips flags some loaders/savers as "unfuzzed": feeding them attacker-supplied files can disclose arbitrary files readable by the process, potentially RCE.

## Changes

1. `config/initializers/vips.rb` — `Vips.block_untrusted(true)`, plus a boot-time guard that refuses libvips < 8.13 (older versions can't block; our `ruby:4.0.1-trixie` image is fine).
2. `ImageUploader` and `ActorImageUploader` — `validation_helpers` plus a `png/jpeg/svg` MIME allowlist. Both had **no validations at all**, so arbitrary uploaded bytes reached libvips with the loader chosen by content sniffing.
3. Specs for both.

## Two things worth knowing

**image_processing already blocks untrusted loaders on require.** `image_processing/vips` calls `block_untrusted` itself, and both uploaders require it — so this is partly mitigated today. What it does not cover is `DeviseMailer#logo` (`app/mailers/devise_mailer.rb:209`), which hands the app's configured `mailer.logo_b64` straight to `Vips::Image.new_from_file`. The initializer removes the load-order dependency.

Side effect of that existing gem behavior: **SVG uploads have been failing since IMB picked up image_processing 2.x** (`Vips::Error`, and with `rescue_from Exception` that surfaces as a generic error). This PR restores them.

**SVG needs the block partially lifted.** librsvg is one of the untrusted loaders, so the initializer re-enables `VipsForeignLoadSvg{File,Buffer,Source}` after blocking — everything else (BMP, ICO, PSD, JPEG XL, JPEG 2000, Netpbm, FITS, ImageMagick delegates) stays blocked. Order matters: the unblock must run *after* `image_processing/vips` is loaded, or its own `block_untrusted` call undoes it. The initializer therefore requires it explicitly, and `spec/lib/vips_blocking_spec.rb` guards that trap.

Residual risk: librsvg stays reachable, but only for content marcel already sniffed as SVG. To drop SVG entirely, delete that block in the initializer and remove `image/svg+xml` from both uploaders.

## Verified

- `bundle exec rspec spec/lib/vips_blocking_spec.rb spec/uploaders/image_uploaders_spec.rb` → 13 examples, 0 failures. Rubocop clean on the added files (the pre-existing offenses in the two uploaders are untouched).
- Covered: Netpbm and other untrusted loaders blocked; PNG/JPEG/SVG still load; SVG still processes through an `ImageProcessing::Vips` pipeline; SVG survives the uploader require that used to re-block it; PDF bytes renamed `.png` are rejected by the allowlist.

## Worth a look in review

- The allowlist newly rejects HEIC, WebP, GIF and TIFF, which upload fine today (their libvips loaders are not untrusted — checked). If clients send iPhone photos as HEIC for user avatars, add `image/heic` (and probably `image/webp`).
- Not addressed: neither uploader has a size limit, and there is no `rescue_from Vips::Error`, so a blocked format that slips past validation lands in `general_error` rather than a 422.
- IMB still ships rails 8.1.3; the 8.1.3.1 patch is unrelated to this fix but worth taking separately.
