### PR TITLE
Clean up orphaned group mappings when clearing a user's tenant access

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -903,7 +903,7 @@ class User < ApplicationDocument
     @access_group_ids = tenant_access_group_ids[tenant_context.to_s] = _resulting_ids
   end
 
-  # Mappings whose target group no longer exists at all (e.g. the group was
+  # Mappings whose target actor no longer exists at all (e.g. the group was
   # deleted/merged elsewhere without cascading the cleanup). These can never
   # show up in tenant_groups_available above, so the unmap loop above can
   # never reach them via unmap_from! — without this, a full removal
@@ -911,9 +911,15 @@ class User < ApplicationDocument
   # Api::V1::AccessControl::Tenant::UsersController#destroy) can never
   # actually clear them, and the same dead group id gets echoed back forever
   # on every subsequent read. Scoped to the whole actor rather than just the
-  # current tenant: once the target group is gone there is no reliable way
-  # to recover which tenant it belonged to, and a mapping to a nonexistent
-  # group is garbage regardless of tenant.
+  # current tenant: once the target is gone there is no reliable way to
+  # recover which tenant it belonged to, and a mapping to a nonexistent
+  # actor is garbage regardless of tenant.
+  # Existence check is against `Actor`, NOT `Actors::Group` — mappings are
+  # not restricted to groups (MAPPABLE_TYPES includes ou/position/tenant
+  # too, e.g. via Api::V1::Apps::Users::ActorsController#create mapping a
+  # user into an arbitrary actor). Actors::Group.where(...) is STI-scoped
+  # to _type: "Actors::Group", so a live Ou/Organization/Tenant/Position
+  # parent would wrongly read as nonexistent and get deleted here.
   # Uses `.delete` (matching unmap_from! and Actors::Mapping.cleanup_orphans!
   # above) rather than `.destroy` — `.destroy` fires Actors::Mapping's
   # `after_destroy :user_cache_expire!`, which calls back into this same
@@ -923,7 +929,7 @@ class User < ApplicationDocument
   # record.cache_expire! right after this method returns.
   def unmap_orphaned_group_memberships!
     Actors::Mapping.where(map_actor: actor).each do |mapping|
-      next if Actors::Group.where(_id: mapping.parent_id).exists?
+      next if Actor.where(_id: mapping.parent_id).exists?
 
       mapping.delete
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -899,7 +899,34 @@ class User < ApplicationDocument
         group.unmap_from!(actor, cache_expire: false)
       end
     end
+    unmap_orphaned_group_memberships!
     @access_group_ids = tenant_access_group_ids[tenant_context.to_s] = _resulting_ids
+  end
+
+  # Mappings whose target group no longer exists at all (e.g. the group was
+  # deleted/merged elsewhere without cascading the cleanup). These can never
+  # show up in tenant_groups_available above, so the unmap loop above can
+  # never reach them via unmap_from! — without this, a full removal
+  # (`access_group_ids = []`, see
+  # Api::V1::AccessControl::Tenant::UsersController#destroy) can never
+  # actually clear them, and the same dead group id gets echoed back forever
+  # on every subsequent read. Scoped to the whole actor rather than just the
+  # current tenant: once the target group is gone there is no reliable way
+  # to recover which tenant it belonged to, and a mapping to a nonexistent
+  # group is garbage regardless of tenant.
+  # Uses `.delete` (matching unmap_from! and Actors::Mapping.cleanup_orphans!
+  # above) rather than `.destroy` — `.destroy` fires Actors::Mapping's
+  # `after_destroy :user_cache_expire!`, which calls back into this same
+  # user's cache/save machinery while we're still inside this user's own
+  # before_save, causing infinite reentrant recursion. `.delete` skips that
+  # callback entirely, which is fine here since do_before_save already calls
+  # record.cache_expire! right after this method returns.
+  def unmap_orphaned_group_memberships!
+    Actors::Mapping.where(map_actor: actor).each do |mapping|
+      next if Actors::Group.where(_id: mapping.parent_id).exists?
+
+      mapping.delete
+    end
   end
 
   def email_blacklisted

--- a/spec/models/user_set_access_group_ids_spec.rb
+++ b/spec/models/user_set_access_group_ids_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+# Regression cover for Samedis-care/samedis-care-issues#2394: an admin
+# removing a user's access to a tenant (Api::V1::AccessControl::Tenant::
+# UsersController#destroy sets access_group_ids = []) reported success
+# while the user's access never actually cleared, because the group
+# backing their membership had been deleted/merged elsewhere without
+# cleaning up the Actors::Mapping join record.
+RSpec.describe User, '#set_access_group_ids=' do
+  let(:sfx) { SecureRandom.hex(4) }
+  let(:email) { "orphan-groups-#{sfx}@access-group-spec.test" }
+
+  let!(:tenant) { Actors::Tenant.create!(name: "t#{sfx}") }
+  let!(:organization) { Actors::Organization.create!(name: "org#{sfx}", parent: tenant) }
+  let!(:tenant_profiles) { Actors::Ou.create!(name: 'tenant_profiles', parent: organization) }
+  let!(:group) { Actors::Group.create!(name: "group#{sfx}", parent: tenant_profiles, system: true) }
+
+  let!(:user) do
+    described_class.new(
+      email: email,
+      email_confirmation: email,
+      first_name: 'Orphan',
+      last_name: 'Groups',
+      password: 'Sup3rSecret!123',
+      password_confirmation: 'Sup3rSecret!123'
+    ).tap do |u|
+      u.skip_confirmation!
+      u.save!
+    end
+  end
+  let!(:user_actor) { user.actor }
+
+  after do
+    Actors::Mapping.where(map_actor: user_actor).delete_all
+    Actor.where(:parent_ids.in => [tenant.id]).delete_all
+    user_actor&.delete
+    user.delete
+    tenant.delete
+  end
+
+  def mappings
+    Actors::Mapping.where(map_actor: user_actor)
+  end
+
+  context 'when a mapped group no longer exists (orphaned mapping)' do
+    before do
+      group.map_into!(user_actor)
+      # the state the underlying bug leaves behind: the mapping survives
+      # a group deletion/merge that should have cascaded
+      group.delete
+    end
+
+    it 'removes the dangling mapping when access is fully cleared' do
+      user.tenant_context = tenant.id
+
+      expect do 
+        user.access_group_ids = []
+        user.save!(validate: false)
+      end
+        .to change(mappings, :count).from(1).to(0)
+    end
+
+    it 'no longer reports the dead group id afterwards' do
+      user.tenant_context = tenant.id
+      user.access_group_ids = []
+      user.save!(validate: false)
+
+      # fresh object — the in-memory User instance memoizes
+      # tenant_access_group_ids across the save, so re-reading the
+      # attribute off `user` itself would return a stale value
+      fresh = described_class.find(user.id)
+      fresh.tenant_context = tenant.id
+      expect(fresh.access_group_ids.to_a).to be_empty
+    end
+  end
+
+  context 'when the group still exists' do
+    it 'still maps a selected group normally (not swept up as if orphaned)' do
+      user.tenant_context = tenant.id
+
+      expect do 
+        user.access_group_ids = [group.id.to_s]
+        user.save!(validate: false)
+      end
+        .to change(mappings, :count).from(0).to(1)
+
+      fresh = described_class.find(user.id)
+      fresh.tenant_context = tenant.id
+      expect(fresh.access_group_ids.to_a).to eq([group.id.to_s])
+    end
+  end
+end

--- a/spec/models/user_set_access_group_ids_spec.rb
+++ b/spec/models/user_set_access_group_ids_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe User, '#set_access_group_ids=' do
     it 'still maps a selected group normally (not swept up as if orphaned)' do
       user.tenant_context = tenant.id
 
-      expect do 
+      expect do
         user.access_group_ids = [group.id.to_s]
         user.save!(validate: false)
       end
@@ -87,6 +87,26 @@ RSpec.describe User, '#set_access_group_ids=' do
       fresh = described_class.find(user.id)
       fresh.tenant_context = tenant.id
       expect(fresh.access_group_ids.to_a).to eq([group.id.to_s])
+    end
+  end
+
+  # Regression for the review finding on PR #275: mappings are not
+  # restricted to groups (Actor::MAPPABLE_TYPES includes ou/position/tenant
+  # too, e.g. Api::V1::Apps::Users::ActorsController#create maps a user
+  # into an arbitrary actor). A mapping into a live non-group actor must
+  # not be swept up as "orphaned" just because it isn't an Actors::Group.
+  context 'when mapped into a live non-group actor (an Ou)' do
+    before { tenant_profiles.map_into!(user_actor) }
+
+    it 'leaves the Ou mapping untouched when clearing access groups elsewhere' do
+      user.tenant_context = tenant.id
+
+      expect do
+        user.access_group_ids = []
+        user.save!(validate: false)
+      end.not_to change(mappings, :count)
+
+      expect(Actors::Mapping.where(parent: tenant_profiles, map_actor: user_actor).first).to be_present
     end
   end
 end


### PR DESCRIPTION
## What

`Api::V1::AccessControl::Tenant::UsersController#destroy` removes a user's access to a tenant by setting `access_group_ids = []`, which is supposed to unmap the user from every access group. `set_access_group_ids=` only iterates `Actors::Group.where(parent_ids: tenant.id)` — groups that currently exist — so it can never reach an `Actors::Mapping` whose target group was deleted/merged elsewhere without cascading the cleanup. The endpoint reports `success: true` while the dead group id keeps getting echoed back on every subsequent read, because `determine_tenant_access_group_ids` rebuilds the cache straight from the (still-dangling) mapping.

Confirmed live against the production report in Samedis-care/samedis-care-issues#2394: both access groups a specific user was cached as belonging to no longer exist as `Actors::Group` documents at all, yet their `Actors::Mapping` join records were still present.

Adds `User#unmap_orphaned_group_memberships!`, called from `set_access_group_ids=`, which removes any mapping for the actor whose parent group no longer resolves at all — regardless of whether the caller explicitly deselected it.

## Why `.delete` and not `.destroy`

`.destroy` fires `Actors::Mapping`'s `after_destroy :user_cache_expire!`, which calls back into the *same* user's cache/save machinery while still inside that user's own `before_save` — a reentrant `SystemStackError`, caught by the regression spec before this ever reached review. `.delete` skips that callback, matching the existing pattern used by `unmap_from!` a few lines above and by the sibling `Actors::Mapping.cleanup_orphans!`. Nothing is lost: `do_before_save` already calls `record.cache_expire!` right after this method returns.

## Verified

- New spec (`spec/models/user_set_access_group_ids_spec.rb`) reproduces the exact bug: maps a user into a group, deletes the group directly (the state the underlying data-integrity gap leaves behind), then confirms `access_group_ids = []` actually clears it.
- Confirmed the spec is a real regression test, not decoration — reverted just the fix and reran:
  ```
  1) ... removes the dangling mapping when access is fully cleared
     expected `Mongoid::Criteria#count` to have changed from 1 to 0, but did not change
  2) ... no longer reports the dead group id afterwards
     expected `["...").empty?` to be truthy, got false
  3 examples, 2 failures
  ```
  Restored the fix, both green again.
- A third case confirms selecting a still-existing group is unaffected (0→1 mapping created normally, not swept up as orphaned).
- `rubocop app/models/user.rb` — zero new offenses in the touched lines (the file has 163 pre-existing offenses elsewhere, untouched by this diff).
- Ran the two other specs that touch this same model area (`spec/migrations/repair_missing_standard_user_mappings_spec.rb`, `spec/lib/apac_migration/leak_guard_spec.rb`) — no new failures; confirmed the 4 failures in the migration spec are pre-existing by running the same file against unmodified `origin/main`.
- Security review: the new method is only reachable through the already-authorized, already-tenant-scoped `destroy`/`update` actions (`cando: ~/access-control.writer`, `tenant_id` intersected against the caller's own tenant memberships). It cannot cross tenant boundaries to delete a *live* mapping under another tenant — a still-existing group anywhere always fails the `exists?` check and is skipped; only mappings whose target is already unrecoverably gone are touched.

## Deliberately left out

- The one-off data cleanup for other tenants/users already carrying this kind of dangling reference (this PR only stops it from recurring going forward) — tracked as a separate task, not a code change.
- `determine_tenant_access_group_ids`'s `.dig(:tenant_access_group_ids)` (symbol key on a hash whose keys likely come back as strings from the raw aggregation) — flagged during investigation as a possibly-separate latent issue, unverified, and would manifest as the *opposite* symptom (access wrongly appearing empty) if real. Not touched here to keep this diff to the one confirmed bug.
- N+1 query in the new method's `.each` loop (one `exists?` check per mapping) — consistent with this method's existing style (`map_into!`/`unmap_from!` per group, unbatched), not a new performance profile. Worth revisiting if a user with very large mapping counts turns up.
