### PR TITLE
Stop before_save from reviving a soft-killed MFA token on any later save

### DIFF
--- a/app/models/concerns/identity_management_extension.rb
+++ b/app/models/concerns/identity_management_extension.rb
@@ -15,8 +15,6 @@ module IdentityManagementExtension
 
     # token will be revoked after this many wrong OTPs
     OTP_MAX_TRIES = 3
-    # after first login this many seconds to supply OTP before token expires
-    OTP_TIME_TO_AUTHENTICATE = 300
     # Allow some seconds of drift (accepts shortly expired code) to compensate server clock drift
     OTP_DRIFT = 60
 
@@ -38,11 +36,26 @@ module IdentityManagementExtension
       # was provided for the token which is checked during JsonApiController#authorize
       if !self.im_otp_required.eql?(false) && self.user.otp_enabled?
         self.im_otp_required = true
-         # limit time to enter an otp before the token expires
-        if self.im_otp_provided
+
+        # Api::V1::Doorkeeper::TokensController#revoke kills a token immediately for
+        # the "soft" logout branch (token_type_hint: 'access_token') via
+        # update_attributes(expires_in: -1). Once expires_in is non-positive the
+        # token is dead and must STAY dead -- checking only "was expires_in changed
+        # in THIS save" is not enough: Api::V1::App::Doorkeeper::TokensController#create
+        # (the refresh_token grant) finds this same token by its still-live
+        # refresh_token, rotates that field, and calls save! on it -- an unrelated
+        # save that doesn't touch expires_in at all, so expires_in_changed? is false
+        # and this branch would otherwise revive a soft-killed token straight back to
+        # the full 30-day lifetime the moment its surviving refresh token is next
+        # used, resurrecting exactly the bug this fix exists to close (#2422).
+        #
+        # `nil` is not "dead" -- every real token-creation path sets expires_in
+        # explicitly, but a bare create without it must still default to a real
+        # lifetime rather than silently persisting nil, which Doorkeeper's
+        # Expirable#expired? treats as "never expires" (strictly more permissive
+        # than intended, not a safe fallback).
+        if expires_in.nil? || expires_in.to_i.positive?
           self.expires_in = Doorkeeper.configuration.access_token_expires_in
-        else
-          self.expires_in = Doorkeeper.configuration.access_token_expires_in #OTP_TIME_TO_AUTHENTICATE
         end
       else
         self.im_otp_required = false

--- a/spec/models/doorkeeper/access_token_identity_management_extension_spec.rb
+++ b/spec/models/doorkeeper/access_token_identity_management_extension_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+# Regression coverage for https://github.com/Samedis-care/samedis-care-issues/issues/2422
+# (Cognisys pentest: session token not destroyed on logout for MFA accounts)
+#
+# Api::V1::Doorkeeper::TokensController#revoke expires a token immediately via
+# `_token.update_attributes(expires_in: -1)` for the "soft" (token_type_hint:
+# 'access_token') logout branch. For an OTP-enabled user, this before_save callback
+# unconditionally reset expires_in back to the full 30-day lifetime on every save --
+# including that very same revoke -- so logout silently never took effect for MFA
+# accounts. Non-MFA accounts were unaffected because the else branch never touches
+# expires_in at all.
+#
+# A first fix only guarded the SAME save that set expires_in (checking
+# expires_in_changed?), which missed a second, real trigger: the refresh_token grant
+# flow (Api::V1::App::Doorkeeper::TokensController#create) finds a soft-revoked
+# token by its still-live refresh_token, rotates that field, and calls save! on it --
+# an unrelated save where expires_in_changed? is false, so that narrower guard would
+# still revive the token. The fix (and the tests below) key off the token's current
+# expires_in value instead, regardless of what this particular save changed.
+RSpec.describe Doorkeeper::AccessToken do
+  def build_user(otp:)
+    user = User.new(
+      email: "identity-management-extension-spec-#{SecureRandom.hex(4)}@test.local",
+      first_name: 'Spec',
+      last_name: 'Probe',
+      password: 'Sup3rSecret!123',
+      password_confirmation: 'Sup3rSecret!123'
+    )
+    user.email_confirmation = user.email
+    user.skip_confirmation!
+    user.save!
+    user.otp_enable! if otp
+    user
+  end
+
+  let(:user) { build_user(otp: otp_enabled) }
+  let!(:token) { described_class.create!(resource_owner_id: user.id) }
+
+  after do
+    token.delete
+    user.delete
+  end
+
+  context 'when the user has MFA/OTP enabled' do
+    let(:otp_enabled) { true }
+
+    it 'persists an explicit soft-expiry (the logout/revoke path) instead of resetting it to the full lifetime' do
+      token.update_attributes(expires_in: -1)
+      token.reload
+
+      expect(token.expires_in).to eq(-1)
+    end
+
+    it 'also protects an explicit expires_in of exactly 0' do
+      token.update_attributes(expires_in: 0)
+      token.reload
+
+      expect(token.expires_in).to eq(0)
+    end
+
+    it 'still resets expires_in to the full lifetime when OTP is being confirmed (unrelated to logout)' do
+      token.update_attributes(
+        im_otp_provided: true, im_otp_tries: 0,
+        expires_in: Doorkeeper.configuration.access_token_expires_in
+      )
+      token.reload
+
+      expect(token.expires_in).to eq(Doorkeeper.configuration.access_token_expires_in)
+      expect(token.im_otp_required).to be(true)
+    end
+
+    it 'still fully kills the token via revoke (the "hard" logout branch, unrelated to expires_in)' do
+      token.revoke
+      token.reload
+
+      expect(token.revoked_at).to be_present
+    end
+
+    it 'stays dead across a later, unrelated save (mirrors the refresh_token grant rotating refresh_token)' do
+      token.update_attributes(expires_in: -1)
+
+      token.refresh_token = Doorkeeper::OAuth::Helpers::UniqueToken.generate
+      token.save!
+      token.reload
+
+      expect(token.expires_in).to eq(-1)
+    end
+
+    it 'defaults a bare create (no explicit expires_in) to the full lifetime instead of leaving it nil' do
+      # every real creation path passes expires_in explicitly, but nil must not be
+      # mistaken for "deliberately killed" -- Doorkeeper::Expirable#expired? treats
+      # nil as "never expires", which is more permissive than intended
+      expect(token.expires_in).to eq(Doorkeeper.configuration.access_token_expires_in)
+    end
+  end
+
+  context 'when the user does not have MFA/OTP enabled' do
+    let(:otp_enabled) { false }
+
+    it 'persists an explicit soft-expiry same as before this fix (never had this bug)' do
+      token.update_attributes(expires_in: -1)
+      token.reload
+
+      expect(token.expires_in).to eq(-1)
+      expect(token.im_otp_required).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## What

Cognisys pentest, July 2026 (PlexTrac `4120693929`): a session token remained valid after logout for accounts with MFA/OTP enabled. Refs #2422 (does not close it -- the samedis-care-backend companion PR, [samedis-care-backend#4129](https://github.com/Samedis-care/samedis-care-backend/pull/4129), fixes a related, separate gap on the same code path; #2422 should stay open until both land).

## Root cause

`Api::V1::Doorkeeper::TokensController#revoke` kills a token immediately for the "soft" logout branch (`token_type_hint: 'access_token'`) via `_token.update_attributes(expires_in: -1)`. For an OTP-enabled user, `IdentityManagementExtension`'s `before_save` callback unconditionally reset `expires_in` back to the full 30-day lifetime on *every* save -- including that very same revoke -- so logout silently never took effect. Non-MFA accounts were unaffected because the `else` branch never touches `expires_in` at all, matching exactly the MFA-only asymmetry Cognisys observed.

## Fix, and a correction along the way

First attempt guarded only the *same* save that set `expires_in` (checking `expires_in_changed?`). A local review round found a second, real trigger before this ever went out for external review: the refresh_token grant flow (`Api::V1::App::Doorkeeper::TokensController#create`) finds a soft-revoked token by its still-live refresh_token (surviving on purpose, per the remembered-account fast path), rotates that field, and calls `save!` on it -- an unrelated save where `expires_in_changed?` is false, so that narrower guard would still silently revive the token the next time its refresh token gets used. Reproduced live against the dev DB before fixing it.

The corrected guard keys off the token's *current* `expires_in` value (nil-or-positive → reset to full lifetime; already non-positive → leave it dead), not what this particular save changed. Also handles a second-order edge the correction introduced: a bare token creation with no explicit `expires_in` must still default to a real lifetime, not `nil` (which Doorkeeper's `Expirable#expired?` treats as "never expires" -- more permissive than intended). Every real token-creation path in this app passes `expires_in` explicitly, so this was unreachable in production, but the new test suite's own bare `create!` would otherwise have hit it silently.

Also removes the dead duplicate `if/else` this replaced (both arms set the identical value) and the now-fully-dead `OTP_TIME_TO_AUTHENTICATE` constant it was the last reference to -- the "short window to enter OTP before the token expires" feature it implies was never actually implemented (both arms always used the full lifetime), as far back as this repo's history goes. Left as an out-of-scope observation, not implemented here -- unrelated to what #2422 asks for.

## What was verified (live, against the real dev DB -- not just reasoning)

- Soft-revoke alone: `expires_in` persists as `-1` (was `2592000` before any fix).
- Soft-revoke followed by an unrelated save (refresh_token rotation, the actual refresh-grant code path): `expires_in` still `-1` (was `2592000` again with the first, narrower guard -- reproduced and confirmed before correcting it).
- A bare create with no explicit `expires_in` for an OTP-enabled user: defaults to the full lifetime, not `nil` (reproduced the nil-default gap with the interim guard, confirmed the correction closes it).
- Unaffected: non-MFA soft revoke, `authenticate_otp`'s own expiry bump, and the "hard" revoke branch (`_token.revoke`, unrelated to `expires_in`).
- `bundle exec rspec spec/models/doorkeeper/access_token_identity_management_extension_spec.rb` -- 7 examples, 0 failures. This repo had no test coverage anywhere for the revoke path before this PR.
- `bundle exec rubocop` on both changed files -- clean (only pre-existing, unrelated offenses in untouched lines).
- A security-focused review pass (token/state manipulation, privilege escalation via `im_otp_required`/`otp_satisfied?`, info leak) plus an 8-angle code review (correctness, removed-behavior, cross-file tracing, reuse, simplification, efficiency, altitude, conventions) -- both are what caught the refresh-token-revival gap and the nil-default edge case above before this ever left local review.

## What's deliberately left out

- The dead `OTP_TIME_TO_AUTHENTICATE` short-window-before-OTP-confirmation feature: never implemented, unrelated to this issue, not built here.
- `self.user.otp_enabled?` runs an ungated `User` fetch on every token save while OTP is required -- pre-existing (not introduced by this diff), possibly deliberate (so a user who just enabled MFA retroactively affects already-issued tokens). Left alone; flagging in case it's worth its own look.
