### PR TITLE
Filter active/expired logins by the token's own expiry, not its age

### DIFF
--- a/app/controllers/api/v1/user/account_logins_controller.rb
+++ b/app/controllers/api/v1/user/account_logins_controller.rb
@@ -2,10 +2,26 @@ class Api::V1::User::AccountLoginsController < Api::V1::JsonApiController
   API = :public
 
   MODEL_BASE = Doorkeeper::AccessToken
+
+  # #destroy resolves through MODEL, #index through MODEL_OVERVIEW (see
+  # Api::V1::JsonApiController#model_destroy / #model_index), and here MODEL is
+  # deliberately WIDER than what the list shows.
+  #
+  # A token soft-killed by logout (Api::V1::Doorkeeper::TokensController#revoke
+  # writes expires_in: -1 for the token_type_hint: 'access_token' branch) is no
+  # longer an active session and is correctly absent from #active_logins -- but its
+  # refresh_token deliberately survives logout, because that is what powers the
+  # remembered-account fast path on the login page. Deleting the record here is the
+  # only way to revoke that surviving refresh credential from a DIFFERENT device
+  # ("forget account" only reaches the browser holding it), so it has to stay
+  # addressable by id even though it is no longer listed (#2422). Scoped to
+  # current_user.oauth_tokens throughout, so this widens nothing across users.
   MODEL = -> {
+    current_user.oauth_tokens.where(revoked_at: nil).order(created_at: -1)
+  }
+  MODEL_OVERVIEW = -> {
     current_user.active_logins.order(created_at: -1)
   }
-  MODEL_OVERVIEW = MODEL
   SERIALIZER = AccountLoginSerializer
   OVERVIEW_SERIALIZER = AccountLoginSerializer
 

--- a/app/models/concerns/identity_management_extension.rb
+++ b/app/models/concerns/identity_management_extension.rb
@@ -28,6 +28,28 @@ module IdentityManagementExtension
     field :im_otp_provided, type: Mongoid::Boolean
     field :im_otp_tries, type: Integer, default: 0
 
+    # Inverse of doorkeeper-mongodb's own `not_expired` scope, restricted to tokens
+    # that were never hard-revoked: tokens whose own expiry window has closed. Used
+    # by User#expired_logins so that pair stays a true partition of a user's
+    # unrevoked tokens (#2422).
+    #
+    # expires_in is per-document, so the comparison needs $expr -- this mirrors the
+    # expression in doorkeeper-mongodb's `not_expired` (mixins/mongoid/
+    # access_token_mixin.rb) with the operator inverted. expires_in is in seconds
+    # while $add treats a plain number added to a date as milliseconds, hence *1000.
+    # A nil expires_in is excluded on purpose: Doorkeeper::Expirable#expired? treats
+    # nil as "never expires", so such a token is active, not expired.
+    scope :expired, -> {
+      where(revoked_at: nil, :expires_in.ne => nil).where(
+        '$expr' => {
+          '$lte' => [
+            { '$add' => ['$created_at', { '$multiply' => ['$expires_in', 1000] }] },
+            Time.now.utc
+          ]
+        }
+      )
+    }
+
     before_create :fill_computed
     before_save :fill_computed
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -877,16 +877,31 @@ class User < ApplicationDocument
     @access_group_ids
   end
 
+  # Sessions the user currently has: not hard-revoked, and their OWN expiry window
+  # still open. Both of these used to derive that window from created_at plus the
+  # GLOBALLY configured lifetime, ignoring the token's own expires_in -- so a token
+  # soft-killed on logout (Api::V1::Doorkeeper::TokensController#revoke writes
+  # expires_in: -1 for the token_type_hint: 'access_token' branch) kept counting as
+  # an active session until its created_at aged past that global lifetime: up to 30
+  # days after the user logged out, in the very screen someone opens to check that
+  # logout worked (#2422). It also kept those sessions out of the account activity
+  # log, which deliberately lists everything that is NOT an active login
+  # (Api::V1::User::AccountActivityController#model_index).
+  #
+  # Doorkeeper::AccessToken.not_expired (from doorkeeper-mongodb) already encodes
+  # exactly this, per document and including revoked_at, so use it rather than
+  # rebuilding the comparison here.
   def active_logins
-    oauth_tokens
-      .where(revoked_at: nil)
-      .where(:created_at.gt => Doorkeeper.configuration.access_token_expires_in.seconds.ago)
+    oauth_tokens.not_expired
   end
 
+  # Complement of #active_logins among tokens that were never hard-revoked: sessions
+  # whose own expiry window has closed, including the soft-killed ones above. Kept a
+  # true complement on purpose -- a soft-killed token's refresh_token deliberately
+  # survives logout (it powers the remembered-account fast path on the login page),
+  # so this is the set whose leftover refresh credentials are still live.
   def expired_logins
-    oauth_tokens
-      .where(revoked_at: nil)
-      .where(:created_at.lte => Doorkeeper.configuration.access_token_expires_in.seconds.ago)
+    oauth_tokens.expired
   end
 
   # this will personalize a formely anonymous token to the user

--- a/spec/controllers/api/v1/user/account_logins_controller_spec.rb
+++ b/spec/controllers/api/v1/user/account_logins_controller_spec.rb
@@ -60,6 +60,22 @@ RSpec.describe Api::V1::User::AccountLoginsController do
     it 'does not list a session that was logged out' do
       expect(controller_instance.send(:model_index).pluck(:_id)).not_to include(soft_killed.id)
     end
+
+    # User#active_logins delegates to doorkeeper-mongodb's `not_expired`, which builds
+    # its condition with Mongoid's `.or` -- the one combinator that treats the
+    # receiver's existing criteria as a branch rather than a conjunct. If a gem
+    # upgrade reshaped that scope so the has_many's resource_owner_id landed inside a
+    # branch instead of above it, this endpoint would quietly list every user's
+    # sessions. Verified by hand once; pinned here so it cannot regress silently.
+    it 'stays scoped to the caller, so it never lists another user\'s session' do
+      other_user = build_user
+      other = Doorkeeper::AccessToken.create!(resource_owner_id: other_user.id, expires_in: full_lifetime)
+
+      expect(controller_instance.send(:model_index).pluck(:_id)).not_to include(other.id)
+    ensure
+      other&.delete
+      other_user&.delete
+    end
   end
 
   describe 'the destroy scope (MODEL)' do

--- a/spec/controllers/api/v1/user/account_logins_controller_spec.rb
+++ b/spec/controllers/api/v1/user/account_logins_controller_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+# Regression coverage for https://github.com/Samedis-care/samedis-care-issues/issues/2422
+#
+# Narrowing User#active_logins to the token's own expiry (so a logged-out session
+# stops showing as active) must NOT also narrow what #destroy can reach. A token
+# soft-killed by logout keeps a live refresh_token on purpose -- that is what powers
+# the remembered-account fast path on the login page -- and deleting the record here
+# is the only way to revoke that leftover credential from a DIFFERENT device. So
+# MODEL (which #destroy resolves through) stays wider than MODEL_OVERVIEW (which
+# #index resolves through).
+#
+# Follows the in-repo convention for controller scoping specs (see
+# spec/controllers/api/v1/user/tenants_controller_spec.rb): instantiate the
+# controller, stub current_user, and drive the real model_* resolvers.
+RSpec.describe Api::V1::User::AccountLoginsController do
+  subject(:controller_instance) { described_class.new }
+
+  def build_user
+    _user = User.new(
+      email: "account-logins-controller-spec-#{SecureRandom.hex(4)}@test.local",
+      first_name: 'Spec',
+      last_name: 'Probe',
+      password: 'Sup3rSecret!123',
+      password_confirmation: 'Sup3rSecret!123'
+    )
+    _user.email_confirmation = _user.email
+    _user.skip_confirmation!
+    _user.save!
+    _user
+  end
+
+  let(:user) { build_user }
+
+  let(:full_lifetime) { Doorkeeper.configuration.access_token_expires_in }
+  # what Api::V1::Doorkeeper::TokensController#revoke writes for the soft logout branch
+  let!(:soft_killed) { Doorkeeper::AccessToken.create!(resource_owner_id: user.id, expires_in: -1) }
+  let!(:live) { Doorkeeper::AccessToken.create!(resource_owner_id: user.id, expires_in: full_lifetime) }
+
+  before do
+    # The test env has no Devise secret configured, so the first lazy route load
+    # (devise_for :users) would raise. Set one so the controller can be exercised.
+    Devise.secret_key ||= 'test-suite-secret'
+
+    without_partial_double_verification do
+      allow(controller_instance).to receive(:current_user).and_return(user)
+    end
+  end
+
+  after do
+    Doorkeeper::AccessToken.where(resource_owner_id: user.id).delete_all
+    user.delete
+  end
+
+  describe 'the index scope (MODEL_OVERVIEW)' do
+    it 'lists the live session' do
+      expect(controller_instance.send(:model_index).pluck(:_id)).to include(live.id)
+    end
+
+    it 'does not list a session that was logged out' do
+      expect(controller_instance.send(:model_index).pluck(:_id)).not_to include(soft_killed.id)
+    end
+  end
+
+  describe 'the destroy scope (MODEL)' do
+    it 'still resolves a logged-out session, so its surviving refresh_token stays revocable' do
+      expect(controller_instance.send(:model_destroy).find(soft_killed.id.to_s)).to eq(soft_killed)
+    end
+
+    it 'still resolves a live session' do
+      expect(controller_instance.send(:model_destroy).find(live.id.to_s)).to eq(live)
+    end
+
+    it 'stays scoped to the caller, so it never reaches another user\'s token' do
+      other_user = build_user
+      other = Doorkeeper::AccessToken.create!(resource_owner_id: other_user.id, expires_in: full_lifetime)
+
+      expect { controller_instance.send(:model_destroy).find(other.id.to_s) }
+        .to raise_error(Mongoid::Errors::DocumentNotFound)
+    ensure
+      other&.delete
+      other_user&.delete
+    end
+  end
+end

--- a/spec/models/user_active_logins_spec.rb
+++ b/spec/models/user_active_logins_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+# Regression coverage for https://github.com/Samedis-care/samedis-care-issues/issues/2422
+# (Cognisys pentest follow-up: a logged-out session still showed as active)
+#
+# User#active_logins / #expired_logins used to derive a token's expiry window from
+# created_at plus the GLOBALLY configured access_token_expires_in, never looking at
+# the token's own expires_in. Api::V1::Doorkeeper::TokensController#revoke kills a
+# token for the "soft" logout branch (token_type_hint: 'access_token') by writing
+# expires_in: -1 and deliberately leaving revoked_at nil, so a just-logged-out
+# session still satisfied both conditions and kept counting as active for up to the
+# full 30-day lifetime -- in exactly the screen a user opens to check that logout
+# worked (Api::V1::User::AccountLoginsController), and it stayed out of the account
+# activity log, which lists everything that is NOT an active login.
+#
+# These tests use a user WITHOUT OTP so IdentityManagementExtension's before_save
+# leaves expires_in alone; the callback's own protection of an explicit expires_in
+# for OTP users is covered by access_token_identity_management_extension_spec.rb.
+RSpec.describe User do
+  subject(:user) do
+    _user = described_class.new(
+      email: "user-active-logins-spec-#{SecureRandom.hex(4)}@test.local",
+      first_name: 'Spec',
+      last_name: 'Probe',
+      password: 'Sup3rSecret!123',
+      password_confirmation: 'Sup3rSecret!123'
+    )
+    _user.email_confirmation = _user.email
+    _user.skip_confirmation!
+    _user.save!
+    _user
+  end
+
+  # `created_at` is written with #set so it bypasses callbacks and timestamping --
+  # the point of these fixtures is a token whose age and expires_in disagree.
+  def create_token(expires_in:, age: nil, revoked: false)
+    token = Doorkeeper::AccessToken.create!(resource_owner_id: user.id, expires_in:)
+    token.set(created_at: age.ago) if age
+    token.revoke if revoked
+    token
+  end
+
+  let(:full_lifetime) { Doorkeeper.configuration.access_token_expires_in }
+
+  # what logout writes: dead now, but revoked_at stays nil and the refresh_token survives
+  let!(:soft_killed)  { create_token(expires_in: -1) }
+  let!(:live)         { create_token(expires_in: full_lifetime) }
+  let!(:aged_out)     { create_token(expires_in: full_lifetime, age: (full_lifetime + 1.day)) }
+  let!(:never_expires) { create_token(expires_in: nil) }
+  let!(:hard_revoked) { create_token(expires_in: full_lifetime, revoked: true) }
+
+  after do
+    Doorkeeper::AccessToken.where(resource_owner_id: user.id).delete_all
+    user.delete
+  end
+
+  describe '#active_logins' do
+    it 'excludes a token soft-killed by logout, even though it was created just now' do
+      expect(user.active_logins.pluck(:_id)).not_to include(soft_killed.id)
+    end
+
+    it 'includes a token whose own expiry window is still open' do
+      expect(user.active_logins.pluck(:_id)).to include(live.id)
+    end
+
+    it 'excludes a token that aged past its own expires_in' do
+      expect(user.active_logins.pluck(:_id)).not_to include(aged_out.id)
+    end
+
+    it 'includes a token with no expires_in (Doorkeeper treats nil as never expiring)' do
+      expect(user.active_logins.pluck(:_id)).to include(never_expires.id)
+    end
+
+    it 'excludes a hard-revoked token' do
+      expect(user.active_logins.pluck(:_id)).not_to include(hard_revoked.id)
+    end
+  end
+
+  describe '#expired_logins' do
+    it 'includes the token soft-killed by logout' do
+      expect(user.expired_logins.pluck(:_id)).to include(soft_killed.id)
+    end
+
+    it 'includes a token that aged past its own expires_in' do
+      expect(user.expired_logins.pluck(:_id)).to include(aged_out.id)
+    end
+
+    it 'excludes a token whose own expiry window is still open' do
+      expect(user.expired_logins.pluck(:_id)).not_to include(live.id)
+    end
+
+    it 'excludes a token with no expires_in (never expires, so never expired)' do
+      expect(user.expired_logins.pluck(:_id)).not_to include(never_expires.id)
+    end
+
+    it 'excludes a hard-revoked token (that is a revoked session, not an expired one)' do
+      expect(user.expired_logins.pluck(:_id)).not_to include(hard_revoked.id)
+    end
+  end
+
+  it 'partitions the unrevoked tokens between the two sets, with no overlap and none dropped' do
+    active = user.active_logins.pluck(:_id)
+    expired = user.expired_logins.pluck(:_id)
+    unrevoked = Doorkeeper::AccessToken.where(resource_owner_id: user.id, revoked_at: nil).pluck(:_id)
+
+    expect(active & expired).to be_empty
+    expect((active + expired).sort).to eq(unrevoked.sort)
+  end
+end


### PR DESCRIPTION
## What

Cognisys pentest follow-up (July 2026, PlexTrac `4120693929`), **related gap 4** of the analysis on Samedis-care/samedis-care-issues#2422: a session that had been properly logged out still showed up as an *active* login. Refs #2422, does not close it -- gaps 1 and 2 of that analysis are untouched (see below).

The reported finding itself, and the samedis-care-side gap 3, are already merged: #277 (`1e8cb51`) and [samedis-care-backend#4129](https://github.com/Samedis-care/samedis-care-backend/pull/4129).

## Root cause

`User#active_logins` and `#expired_logins` derived a token's expiry window from `created_at` plus the **globally** configured `access_token_expires_in`, and never looked at the token's own `expires_in`.

`Api::V1::Doorkeeper::TokensController#revoke` kills a token for the "soft" logout branch (`token_type_hint: 'access_token'`) by writing `expires_in: -1` while deliberately leaving `revoked_at` nil -- the refresh token has to survive, because that is what powers the remembered-account fast path on the login page. So a just-logged-out session satisfied both of the old conditions and kept counting as active for up to the full 30-day lifetime, in exactly the screen a user opens to check whether logout worked.

The same miscount also kept those sessions **out of** the account activity log, which deliberately lists everything that is *not* an active login (`Api::V1::User::AccountActivityController#model_index`) -- so a logged-out session was simultaneously shown as active and missing from the history.

Reproduced against the dev DB: 6 of the 323 tokens the old logic reported as active were already soft-killed, spread over 3 users, and all 6 have an `AccountActivity` record that was being suppressed. The new logic reports 317.

## The change

`active_logins` now just delegates to doorkeeper-mongodb's own `not_expired` scope, which already encodes exactly this per document -- including `revoked_at`, and treating a nil `expires_in` as "never expires" per `Doorkeeper::Expirable#expired?`. No reason to rebuild that comparison by hand.

`expired_logins` gets the inverse as a new `expired` scope on the token model, so the pair stays a true partition of a user's unrevoked tokens. It has no callers today, but leaving one half on the old `created_at` arithmetic would hand the next person a subtly wrong sibling -- and after this change a soft-killed token would otherwise have fallen out of *both* sets.

### The part that is not cosmetic

Narrowing the scope would have silently removed a capability, so this PR keeps it explicitly. `#destroy` resolves through `MODEL`, `#index` through `MODEL_OVERVIEW`, and in `Api::V1::User::AccountLoginsController` both pointed at `active_logins`. A soft-killed token's `refresh_token` is still live on purpose, and deleting the record is the only way to revoke that leftover credential from a **different** device -- "forget account" only reaches the browser holding it. `MODEL` is therefore now deliberately wider than `MODEL_OVERVIEW`: unrevoked own tokens, still scoped to `current_user.oauth_tokens`, so nothing widens across users.

## What was verified

Both specs were confirmed **red against the pre-fix code first**, not just green after:

```
# reverting user.rb only
11 examples, 2 failures
  User#active_logins excludes a token soft-killed by logout, even though it was created just now
  User#expired_logins includes the token soft-killed by logout

# narrowing MODEL back to active_logins
5 examples, 1 failure
  the destroy scope (MODEL) still resolves a logged-out session, so its surviving refresh_token stays revocable
```

- The `$expr` query cross-checked against a pure-Ruby expiry computation over a 431-token mixed sample (8 dead, 423 alive) -- **identical id sets**, not merely identical counts. My first cross-check ran over the oldest 3000 tokens and matched at `0 == 0`; that was a check that could not fail, so it was redone against a sample that actually contains both cases.
- The scope survives the full index chain the base controller builds (`quickfilter` / `gridfilter` / `auto_includes` / `sorting` / `paginate`): selector keeps the `$or`, no soft-dead token leaks through.
- No nil `created_at` anywhere in the collection (such a document would fall out of both sets and break the partition), and `resource_owner_id` is indexed, so the `$expr` only ever evaluates over one user's tokens.
- A second `include IdentityManagementExtension` does not raise `Mongoid::Errors::ScopeOverwrite`, so adding a `scope` to a concern that an initializer pushes into a gem class is safe here.
- `Api::V1::User::AuthenticateOtpController` also names `active_logins` as `MODEL`, but `index`/`show`/`update`/`destroy` are undef'd there and `create` is overridden to use `current_token` -- and no `before_action` in the base controller evaluates `MODEL`, so the OTP login path is untouched. Checked, because narrowing this scope wrongly would have broken MFA login outright.
- `spec/models` + `spec/controllers`: 136 examples, 0 failures. No spec fixtures left behind in the shared dev DB.
- rubocop: **zero new offenses** in the three app files (163 / 34 / 2, unchanged against `origin/main`); the remaining spec-file cops are the same ones the already-merged specs in this repo carry.

The second commit came out of the local review pass rather than from a reviewer: nothing asserted that the *index* scope stays restricted to the requesting user. `not_expired` builds its condition with Mongoid's `.or`, the one combinator that folds the receiver's criteria into a branch instead of ANDing onto it. The `resource_owner_id` does still land above the `$or` today, so there is no leak -- but a gem upgrade reshaping that scope would turn this endpoint into a cross-user session listing with nothing going red. Pinned, and confirmed the guard fails when `active_logins` is pointed at an unscoped `not_expired`.

## Deliberately out of scope

- **Frontend follow-up, filed separately, not papered over here:** the sessions that are now correctly absent from the active list still hold a live `refresh_token`, and there is no UI to see or revoke them. `expired_logins` is the set to build that on.
- **Gap 1** (the remembered-account skip is effectively a 30-day MFA-satisfied credential in `localStorage`) -- a product decision, not a code fix.
- **Gap 2** (the refresh grant does not retire the old access token) -- real, separate change, touches the remembered-account logic.
- A hard-revoked token that is *also* past its expiry is in neither set. That is deliberate -- it is a revoked session, not an expired one -- and matches the previous behaviour, since `expired_logins` already filtered on `revoked_at: nil`.

## Risk

The behaviour change is user-visible in two places by design: the active-logins list gets shorter, and the account activity log gets longer by the same sessions. Both were verified against real data, but only on the dev DB -- production has a larger and older token population, and the only shape that would behave differently there is a document with a nil `created_at`, which does not exist in dev.

Not verified end-to-end through HTTP: these are scope-level specs following this repo's existing controller-spec convention (`spec/controllers/api/v1/user/tenants_controller_spec.rb`), so the serializer and route layers above `model_index` / `model_destroy` are covered by inspection only.
