### PR TITLE
Report puma worker crashes from the master process

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -103,7 +103,3 @@ Sentry.init do |config|
     end
   end
 end
-
-if $sentry_report_worker_crash # global variable, see puma.rb
-  Sentry.capture_message("PUMA: Worker Crash detected")
-end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,8 +32,6 @@ preload_app!
 
 persistent_timeout 90
 
-start_time = Time.now.to_f # captured in main process (process managing workers)
-$sentry_report_worker_crash = false # global variable
 puma_in_cluster_mode = false
 
 require_relative '../lib/heap_dumper'
@@ -50,17 +48,71 @@ end
 before_worker_boot do
   # runs in worker context
 
-  # code run inside worker processes. workers are copies of the main process, so start_time is filled with the main process start time.
-  # this code runs very early. Sentry is not initialized here, so we can't report to Sentry yet.
-  now = Time.now.to_f
-  if now - start_time > 5 # if time of worker start is >5 seconds (usually < 0.1 sec) after main process start
-    puts "WORKER CRASH DETECTED"
-    $sentry_report_worker_crash = true # this will trigger a Sentry.capture_message in sentry.rb, thus reporting the issue to Sentry after init.
-  end
-
   MaintenanceMode.start
   puts "[#{Process.pid}] Maintenance mode started."
   HeapDumper.start
+end
+
+# Worker crash reporting (cluster mode only).
+#
+# Runs in the master process every time a worker process is reaped, so it sees
+# the actual exit status instead of guessing from a worker's boot time. Because
+# preload_app! boots Rails - and with it config/initializers/sentry.rb - in the
+# master before the first fork, Sentry is initialized here and the crash can be
+# reported immediately.
+#
+# Do NOT move this back into a worker hook: worker hooks run after the fork, so
+# state they set (a global, an ivar, ...) is invisible to the initializers, which
+# already ran in the master while preloading. That is why the previous
+# $sentry_report_worker_crash flag never reached Sentry.
+after_worker_shutdown do |worker|
+  status = worker.process_status # Process::Status, nil if it could not be determined
+
+  # graceful stop (shutdown / hot restart / phased restart): puma asked the worker
+  # to terminate and it exited cleanly - nothing to report
+  next if worker.term? && status&.success?
+
+  # puma sends SIGKILL itself when a worker misses its check-in (worker_timeout)
+  # or overruns worker_shutdown_timeout; the OOM killer uses SIGKILL as well
+  reason = if status.nil?
+             'exit status unknown'
+           elsif status.signaled?
+             "killed by signal #{status.termsig}"
+           else
+             "exited with status #{status.exitstatus}"
+           end
+  kind = if status.nil?
+           'unknown'
+         elsif status.signaled?
+           "signal_#{status.termsig}"
+         else
+           "exit_#{status.exitstatus}"
+         end
+
+  puts "[#{Process.pid}] WORKER CRASH DETECTED: worker #{worker.index} (pid #{worker.pid}) #{reason} " \
+       "after #{worker.uptime.round(1)}s (booted: #{worker.booted?}, terminating: #{worker.term?})"
+
+  next unless defined?(Sentry) && Sentry.initialized?
+
+  # worker.term? separates "died out of nowhere" from "was asked to stop but had to
+  # be killed" - keep them as two Sentry issues, the message must stay static so
+  # crashes group together instead of one issue per pid
+  message = worker.term? ? 'PUMA: Worker did not shut down cleanly' : 'PUMA: Worker Crash detected'
+
+  Sentry.capture_message(
+    message,
+    level: :error,
+    tags: { puma_worker_exit: kind },
+    extra: {
+      worker_index: worker.index,
+      worker_pid: worker.pid,
+      worker_phase: worker.phase,
+      uptime_seconds: worker.uptime.round(1),
+      booted: worker.booted?,
+      terminating: worker.term?,
+      reason: reason
+    }
+  )
 end
 
 before_worker_shutdown do


### PR DESCRIPTION
Ports Samedis-care/samedis-care-backend#4188 to IMB. Same root cause and same fix — this repo carried an identical copy of the broken hand-off.

Refs Samedis-care/samedis-care-issues#2539

## Problem

Worker crashes were never reported to Sentry. The `$sentry_report_worker_crash` hand-off between `config/puma.rb` and `config/initializers/sentry.rb` could not work with `preload_app!`:

1. Puma parses `config/puma.rb` → `$sentry_report_worker_crash = false`
2. Puma **preloads the Rails app in the master** → every initializer runs, so the `if $sentry_report_worker_crash` check at the bottom of `sentry.rb` evaluates **once, in the master, as `false`**
3. *Then* Puma forks → `before_worker_boot` sets the flag to `true` in the worker

Nothing reads the flag after step 3 — forked workers do not re-run initializers. The `WORKER CRASH DETECTED` log line appeared, the Sentry event never did.

The detection heuristic was unsound regardless: `start_time` was captured while the config file was parsed, i.e. *before* the multi-second Rails preload, so `now - start_time > 5` was true for every worker of a normal cold boot.

## Fix

Report from the **master** via Puma's `after_worker_shutdown` hook. It receives the `WorkerHandle` with the actual `Process::Status`, Sentry is initialized in that process (preload ran its initializer there), and no cross-process state is involved.

- Graceful stops (`term?` + exit 0) are skipped — shutdown, hot restart, phased restart stay silent.
- Workers that had to be `SIGKILL`ed *after* being asked to terminate get their own message (`PUMA: Worker did not shut down cleanly`) so deploy-time shutdown timeouts don't pollute the crash issue.
- The message string stays static so crashes group into one Sentry issue; pid/index/uptime/exit status go to `extra`, and `puma_worker_exit` (`signal_9`, `exit_3`, …) is a tag for filtering.
- Dead `if $sentry_report_worker_crash` block removed from the initializer.
- `before_worker_boot` keeps `MaintenanceMode.start` / `HeapDumper.start` unchanged; only the crash heuristic is removed.

`concurrent-ruby` 1.3.7 (the version pinned here, SCB is on 1.3.8) resets its thread pool on fork via `ns_reset_if_forked` — verified in the installed gem — so a master-side Sentry capture cannot poison delivery in workers forked afterwards.

## Verification

Checked against this repo's actual gems, Puma 8.0.2 / Ruby 4.0.1:

- `after_worker_shutdown` exists as a `cluster_only` hook, and `WorkerHandle` exposes every attribute used here (`process_status`, `term?`, `index`, `pid`, `phase`, `uptime`, `booted?`). `Cluster#reap_workers` assigns `w.process_status = status` on the line directly before it runs the hook, so the status is always populated.

Standalone Puma cluster (`workers 2`, `preload_app!`, hook block copied verbatim out of `config/puma.rb`, `Sentry` stubbed in `config.ru` so it loads during preload like the real initializer):

| scenario | result |
|---|---|
| `kill -9` a worker (OOM-kill / hard crash) | `worker 0 (pid 31057) killed by signal 9 after 16.0s (booted: true, terminating: false)` → `PUMA: Worker Crash detected`, `puma_worker_exit=signal_9` |
| worker `exit!(3)` on its own (app-level crash) | `exited with status 3 after 3.1s` → `PUMA: Worker Crash detected`, `puma_worker_exit=exit_3` — fired again on the replacement worker |
| `SIGTERM` graceful shutdown | silent, as intended |

The preload line logged `PRELOAD: app loaded, Sentry.initialized?=true` under the **master** pid, and every crash line was prefixed with that same master pid — confirming the premise the fix rests on.

`ruby -c` passes on both files. Rubocop offense count on the two files drops from 29 to 21 with no new offenses introduced; the remainder are pre-existing (`Rails/Output` for the `puts` calls, and `sentry.rb` string/layout style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
